### PR TITLE
feat: style refinements for brand consistency

### DIFF
--- a/packages/ardo/src/config/index.ts
+++ b/packages/ardo/src/config/index.ts
@@ -51,8 +51,8 @@ const defaultThemeConfig: ThemeConfig = {
 
 const defaultMarkdownConfig: MarkdownConfig = {
   theme: {
-    light: "github-light",
-    dark: "github-dark",
+    light: "github-light-default",
+    dark: "github-dark-default",
   },
   lineNumbers: false,
   anchor: true,

--- a/packages/ardo/src/ui/styles.css
+++ b/packages/ardo/src/ui/styles.css
@@ -51,9 +51,9 @@
   --ardo-sidebar-bg: oklch(0.975 0.006 var(--ardo-brand-h));
   --ardo-sidebar-border: oklch(0.925 0.01 var(--ardo-brand-h));
 
-  /* Code block styling - warm cream tone */
-  --ardo-code-bg: #fdfcfb;
-  --ardo-code-border: #f0ebe4;
+  /* Code block styling - derived from brand hue */
+  --ardo-code-bg: oklch(0.985 0.004 var(--ardo-brand-h));
+  --ardo-code-border: oklch(0.92 0.008 var(--ardo-brand-h));
   --ardo-code-shadow: 0 1px 3px rgba(0, 0, 0, 0.03);
 
   /* ========================================
@@ -142,8 +142,8 @@
   --ardo-sidebar-bg: oklch(0.18 0.018 var(--ardo-brand-h));
   --ardo-sidebar-border: oklch(0.28 0.02 var(--ardo-brand-h));
 
-  --ardo-code-bg: #1c1917;
-  --ardo-code-border: #292524;
+  --ardo-code-bg: oklch(0.17 0.01 var(--ardo-brand-h));
+  --ardo-code-border: oklch(0.25 0.015 var(--ardo-brand-h));
   --ardo-code-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
 
   /* Light text on dark (brand-tinted) */
@@ -654,6 +654,7 @@ body {
   padding-bottom: 10px;
   border-bottom: none;
   position: relative;
+  letter-spacing: -0.02em;
 }
 
 .ardo-content h2::after {
@@ -1632,8 +1633,16 @@ body {
   height: 48px;
   margin-bottom: 16px;
   background: var(--ardo-c-brand-subtle);
+  border: 1px solid oklch(var(--ardo-brand-l) var(--ardo-brand-c) var(--ardo-brand-h) / 0.12);
   border-radius: var(--ardo-radius);
   color: var(--ardo-c-brand);
+  transition: all var(--ardo-transition);
+}
+
+.ardo-feature:hover .ardo-feature-icon {
+  background: var(--ardo-c-brand);
+  color: white;
+  border-color: transparent;
 }
 
 .ardo-feature-title {


### PR DESCRIPTION
## Summary

- **Brand-tinted code blocks**: Derive `--ardo-code-bg` and `--ardo-code-border` from `--ardo-brand-h` using OKLCH instead of hardcoded warm cream hex values (`#fdfcfb`/`#f0ebe4` in light, `#1c1917`/`#292524` in dark). Code blocks now adapt automatically when users customize their brand hue.
- **Better default Shiki theme**: Switch from `github-light`/`github-dark` to `github-light-default`/`github-dark-default` for improved syntax contrast and readability.
- **Feature icon hover**: Add a subtle hover effect that inverts the feature icon to brand color with white foreground, plus a light border for better definition at rest.
- **Heading letter-spacing**: Tighten `h2` to `-0.02em` for stronger visual hierarchy (h3+ keeps the existing `-0.01em`).

## Test plan

- [ ] Verify code blocks look correct in both light and dark mode with default brand hue (170)
- [ ] Verify code blocks adapt when `--ardo-brand-h` is customized (e.g. 245 for blue)
- [ ] Verify Shiki syntax highlighting has good contrast with the new default themes
- [ ] Hover over feature cards and confirm icon color inversion
- [ ] Check h2 heading spacing looks tighter than h3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default Markdown theme identifiers for improved consistency between light and dark viewing modes.
  * Enhanced code block appearance with refined color and border styling.
  * Refined typography with tighter letter-spacing to improve overall readability.
  * Upgraded feature icon styling with smooth state transitions and interactive hover effects for enhanced user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->