### PR TITLE
fix: align vite plugin Shiki theme fallbacks with config defaults

### DIFF
--- a/packages/ardo/src/vite/plugin.ts
+++ b/packages/ardo/src/vite/plugin.ts
@@ -351,14 +351,14 @@ export function ardoPlugin(options: ArdoPluginOptions = {}): Plugin[] {
   const shikiOptions = hasThemeObject
     ? {
         themes: {
-          light: themeConfig.light || "github-light",
-          dark: themeConfig.dark || "github-dark",
+          light: themeConfig.light || "github-light-default",
+          dark: themeConfig.dark || "github-dark-default",
         },
         defaultColor: false as const,
         transformers: [ardoLineTransformer({ globalLineNumbers: lineNumbers })],
       }
     : {
-        theme: (themeConfig as string) || "github-dark",
+        theme: (themeConfig as string) || "github-dark-default",
         transformers: [ardoLineTransformer({ globalLineNumbers: lineNumbers })],
       }
 


### PR DESCRIPTION
## Summary

- The config module (`config/index.ts`) was updated in #38 to default to `github-light-default`/`github-dark-default`
- But the vite plugin (`vite/plugin.ts`) has its own hardcoded fallbacks that still used the old `github-light`/`github-dark` themes
- Since the vite plugin builds the Shiki options directly, its fallbacks take precedence — so the config change had no effect

This aligns all three fallback values in the vite plugin with the config defaults.

## Test plan

- [ ] Build a docs site without specifying `markdown.theme` and verify code blocks use `github-light-default`/`github-dark-default`
- [ ] Verify custom theme overrides still work when explicitly set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default theme fallback names for improved consistency in the theme configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->