### PR TITLE
fix: use package name instead of 'index' for TypeDoc module names

### DIFF
--- a/packages/ardo/package.json
+++ b/packages/ardo/package.json
@@ -69,6 +69,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.13.0",
+    "read-package-up": "^12.0.0",
     "rehype-parse": "^9.0.1",
     "rehype-stringify": "^10.0.1",
     "remark-directive": "^4.0.0",

--- a/packages/ardo/src/typedoc/generator.ts
+++ b/packages/ardo/src/typedoc/generator.ts
@@ -10,7 +10,7 @@ import {
 } from "typedoc"
 import path from "path"
 import fs from "fs/promises"
-import fsSync from "fs"
+import { readPackageUp } from "read-package-up"
 import type { TypeDocConfig, GeneratedApiDoc } from "./types"
 
 export class TypeDocGenerator {
@@ -43,10 +43,11 @@ export class TypeDocGenerator {
     }
     // Use the output directory as the base path for links
     this.basePath = "/" + this.config.out!
-    this.packageName = this.resolvePackageName()
   }
 
   async generate(outputDir: string): Promise<GeneratedApiDoc[]> {
+    this.packageName = await this.resolvePackageName()
+
     const typedocOptions: Record<string, unknown> = {
       entryPoints: this.config.entryPoints,
       tsconfig: this.config.tsconfig,
@@ -454,26 +455,19 @@ export class TypeDocGenerator {
     }
   }
 
-  private resolvePackageName(): string | undefined {
+  private async resolvePackageName(): Promise<string | undefined> {
     const entryPoint = this.config.entryPoints[0]
     if (!entryPoint) return undefined
 
-    let dir = path.dirname(path.resolve(entryPoint))
-    const root = path.parse(dir).root
+    const result = await readPackageUp({
+      cwd: path.dirname(path.resolve(entryPoint)),
+    })
 
-    while (dir !== root) {
-      const pkgPath = path.join(dir, "package.json")
-      try {
-        const pkg = JSON.parse(fsSync.readFileSync(pkgPath, "utf-8"))
-        if (pkg.name) {
-          return pkg.name.replace(/^@[^/]+\//, "")
-        }
-      } catch {
-        // No package.json here, keep walking up
-      }
-      dir = path.dirname(dir)
-    }
-    return undefined
+    const name = result?.packageJson.name
+    if (!name) return undefined
+
+    // Strip scope prefix: @org/name -> name
+    return name.replace(/^@[^/]+\//, "")
   }
 
   private getModuleNameFromPath(filePath: string): string {

--- a/packages/ardo/src/typedoc/generator.ts
+++ b/packages/ardo/src/typedoc/generator.ts
@@ -10,6 +10,7 @@ import {
 } from "typedoc"
 import path from "path"
 import fs from "fs/promises"
+import fsSync from "fs"
 import type { TypeDocConfig, GeneratedApiDoc } from "./types"
 
 export class TypeDocGenerator {
@@ -17,6 +18,7 @@ export class TypeDocGenerator {
   private app: Application | undefined
   private project: ProjectReflection | undefined
   private basePath: string
+  private packageName: string | undefined
 
   constructor(config: TypeDocConfig) {
     this.config = {
@@ -41,6 +43,7 @@ export class TypeDocGenerator {
     }
     // Use the output directory as the base path for links
     this.basePath = "/" + this.config.out!
+    this.packageName = this.resolvePackageName()
   }
 
   async generate(outputDir: string): Promise<GeneratedApiDoc[]> {
@@ -451,6 +454,28 @@ export class TypeDocGenerator {
     }
   }
 
+  private resolvePackageName(): string | undefined {
+    const entryPoint = this.config.entryPoints[0]
+    if (!entryPoint) return undefined
+
+    let dir = path.dirname(path.resolve(entryPoint))
+    const root = path.parse(dir).root
+
+    while (dir !== root) {
+      const pkgPath = path.join(dir, "package.json")
+      try {
+        const pkg = JSON.parse(fsSync.readFileSync(pkgPath, "utf-8"))
+        if (pkg.name) {
+          return pkg.name.replace(/^@[^/]+\//, "")
+        }
+      } catch {
+        // No package.json here, keep walking up
+      }
+      dir = path.dirname(dir)
+    }
+    return undefined
+  }
+
   private getModuleNameFromPath(filePath: string): string {
     // Include parent directory to avoid naming conflicts
     // "src/utils/string.ts" -> "utils/string"
@@ -463,6 +488,9 @@ export class TypeDocGenerator {
     const parent = parts.pop()
     if (parent && parent !== "src") {
       return `${parent}/${basename}`
+    }
+    if (basename === "index" && this.packageName) {
+      return this.packageName
     }
     return basename
   }

--- a/packages/ardo/src/typedoc/generator.ts
+++ b/packages/ardo/src/typedoc/generator.ts
@@ -18,7 +18,7 @@ export class TypeDocGenerator {
   private app: Application | undefined
   private project: ProjectReflection | undefined
   private basePath: string
-  private packageName: string | undefined
+  private packageNameCache = new Map<string, string | undefined>()
 
   constructor(config: TypeDocConfig) {
     this.config = {
@@ -46,7 +46,8 @@ export class TypeDocGenerator {
   }
 
   async generate(outputDir: string): Promise<GeneratedApiDoc[]> {
-    this.packageName = await this.resolvePackageName()
+    // Pre-populate package name cache for all entry points
+    await Promise.all(this.config.entryPoints.map((ep) => this.resolvePackageName(ep)))
 
     const typedocOptions: Record<string, unknown> = {
       entryPoints: this.config.entryPoints,
@@ -455,19 +456,17 @@ export class TypeDocGenerator {
     }
   }
 
-  private async resolvePackageName(): Promise<string | undefined> {
-    const entryPoint = this.config.entryPoints[0]
-    if (!entryPoint) return undefined
+  private async resolvePackageName(filePath: string): Promise<string | undefined> {
+    const dir = path.dirname(path.resolve(filePath))
+    if (this.packageNameCache.has(dir)) {
+      return this.packageNameCache.get(dir)
+    }
 
-    const result = await readPackageUp({
-      cwd: path.dirname(path.resolve(entryPoint)),
-    })
-
+    const result = await readPackageUp({ cwd: dir })
     const name = result?.packageJson.name
-    if (!name) return undefined
-
-    // Strip scope prefix: @org/name -> name
-    return name.replace(/^@[^/]+\//, "")
+    const resolved = name ? name.replace(/^@[^/]+\//, "") : undefined
+    this.packageNameCache.set(dir, resolved)
+    return resolved
   }
 
   private getModuleNameFromPath(filePath: string): string {
@@ -483,8 +482,10 @@ export class TypeDocGenerator {
     if (parent && parent !== "src") {
       return `${parent}/${basename}`
     }
-    if (basename === "index" && this.packageName) {
-      return this.packageName
+    if (basename === "index") {
+      const dir = path.dirname(path.resolve(filePath))
+      const packageName = this.packageNameCache.get(dir)
+      if (packageName) return packageName
     }
     return basename
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ importers:
       react-router:
         specifier: ^7.13.0
         version: 7.13.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      read-package-up:
+        specifier: ^12.0.0
+        version: 12.0.0
       rehype-parse:
         specifier: ^9.0.1
         version: 9.0.1
@@ -1257,6 +1260,9 @@ packages:
   '@types/node@25.2.2':
     resolution: {integrity: sha512-BkmoP5/FhRYek5izySdkOneRyXYN35I860MFAGupTdebyE66uZaR+bXLHq8k4DirE5DwQi3NuhvRU1jqTVwUrQ==}
 
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
   '@types/prompts@2.4.9':
     resolution: {integrity: sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==}
 
@@ -1867,6 +1873,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-up-simple@1.0.1:
+    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
+    engines: {node: '>=18'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -2007,6 +2017,10 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hosted-git-info@9.0.2:
+    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
@@ -2026,6 +2040,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  index-to-position@1.2.0:
+    resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
+    engines: {node: '>=18'}
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -2344,6 +2362,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.2.6:
+    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2591,6 +2613,10 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  normalize-package-data@8.0.0:
+    resolution: {integrity: sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -2654,6 +2680,10 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-json@8.3.0:
+    resolution: {integrity: sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==}
+    engines: {node: '>=18'}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -2783,6 +2813,14 @@ packages:
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  read-package-up@12.0.0:
+    resolution: {integrity: sha512-Q5hMVBYur/eQNWDdbF4/Wqqr9Bjvtrw2kjGxxBbKLbx8bVCL8gcArjTy8zDUuLGQicftpMuU0riQNcAsbtOVsw==}
+    engines: {node: '>=20'}
+
+  read-pkg@10.1.0:
+    resolution: {integrity: sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==}
+    engines: {node: '>=20'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -2980,6 +3018,18 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -3049,6 +3099,10 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
@@ -3135,6 +3189,14 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  type-fest@5.4.4:
+    resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
+    engines: {node: '>=20'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -3183,6 +3245,10 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
+  unicorn-magic@0.4.0:
+    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
+    engines: {node: '>=20'}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -3223,6 +3289,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -4330,6 +4399,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/normalize-package-data@2.4.4': {}
+
   '@types/prompts@2.4.9':
     dependencies:
       '@types/node': 25.2.2
@@ -5138,6 +5209,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up-simple@1.0.1: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -5354,6 +5427,10 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hosted-git-info@9.0.2:
+    dependencies:
+      lru-cache: 11.2.6
+
   html-void-elements@3.0.0: {}
 
   husky@9.1.7: {}
@@ -5363,6 +5440,8 @@ snapshots:
   ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
+
+  index-to-position@1.2.0: {}
 
   inline-style-parser@0.2.7: {}
 
@@ -5654,6 +5733,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@11.2.6: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -6203,6 +6284,12 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  normalize-package-data@8.0.0:
+    dependencies:
+      hosted-git-info: 9.0.2
+      semver: 7.7.4
+      validate-npm-package-license: 3.0.4
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -6287,6 +6374,12 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse-json@8.3.0:
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      index-to-position: 1.2.0
+      type-fest: 4.41.0
 
   parse5@7.3.0:
     dependencies:
@@ -6381,6 +6474,20 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
+
+  read-package-up@12.0.0:
+    dependencies:
+      find-up-simple: 1.0.1
+      read-pkg: 10.1.0
+      type-fest: 5.4.4
+
+  read-pkg@10.1.0:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 8.0.0
+      parse-json: 8.3.0
+      type-fest: 5.4.4
+      unicorn-magic: 0.4.0
 
   readdirp@4.1.2: {}
 
@@ -6717,6 +6824,20 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
+
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
@@ -6816,6 +6937,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tagged-tag@1.0.0: {}
+
   tailwindcss@4.1.18: {}
 
   thenify-all@1.6.0:
@@ -6900,6 +7023,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  type-fest@4.41.0: {}
+
+  type-fest@5.4.4:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typed-array-buffer@1.0.3:
     dependencies:
       call-bound: 1.0.4
@@ -6968,6 +7097,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
+  unicorn-magic@0.4.0: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -7028,6 +7159,11 @@ snapshots:
   valibot@1.2.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
 
   vfile-location@5.0.3:
     dependencies:


### PR DESCRIPTION
## Summary

- Fixes `getModuleNameFromPath` returning the literal string "index" when entry point is `src/index.ts`
- Resolves the package name from the nearest `package.json` (stripping scope prefix) and uses it as the module name
- Falls back to "index" only if no `package.json` is found

### Before
```
## Functions
- [index](/api-reference/functions) - addRule, configureRule, ...
```

### After
```
## Functions
- [my-package](/api-reference/functions) - addRule, configureRule, ...
```

Closes #54

## Test plan

- [ ] Run TypeDoc generation on a package with `src/index.ts` as entry point and verify the module name shows the package name
- [ ] Run TypeDoc generation with non-index entry points and verify behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced package name resolution in the documentation generator for more accurate module identification in generated documentation, particularly for index files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->