### PR TITLE
Move search into the header with a mobile overlay

### DIFF
--- a/packages/ardo/src/ui/ArdoRoot.tsx
+++ b/packages/ardo/src/ui/ArdoRoot.tsx
@@ -4,7 +4,6 @@ import { Outlet, useLocation, useMatches } from "react-router"
 import type { ArdoConfig, ArdoContextItem, SidebarItem } from "../config/types"
 
 import { ArdoProvider, type ArdoSiteConfig, ArdoSiteConfigProvider } from "../runtime/hooks"
-import { ArdoSearch } from "./components/Search"
 import { ArdoFooter, type ArdoFooterProps } from "./Footer"
 import { ArdoHeader, type ArdoHeaderProps } from "./Header"
 import { ArdoLayout } from "./Layout"
@@ -199,16 +198,11 @@ export function ArdoRoot({
     () => resolveContextSidebar(sidebar, activeContext),
     [sidebar, activeContext]
   )
-  const searchPlaceholder = headerProps?.searchPlaceholder
-  const showSearch = headerProps?.search !== false
-  const sidebarSearch =
-    !isBareLayout && showSearch ? <ArdoSearch placeholder={searchPlaceholder} /> : undefined
-  const resolvedSidebar = isBareLayout
-    ? undefined
-    : wrapSidebarWithSearch(sidebarContent, sidebarProps, sidebarSearch)
+  // Search lives in the header now. The sidebar no longer carries it.
+  const resolvedSidebar = isBareLayout ? undefined : resolveSidebar(sidebarContent, sidebarProps)
   const resolvedHeader = resolveRootHeader(
     header,
-    { ...headerProps, search: false },
+    headerProps,
     isBareLayout ? undefined : resolvedSidebar
   )
 
@@ -245,29 +239,20 @@ export function ArdoRoot({
 }
 
 /**
- * Wraps sidebar content with a search field header.
- * If the user provides custom sidebarContent (which is typically an <ArdoSidebar>),
- * we clone it and inject the search as its `header` prop.
- * Otherwise we create a default <ArdoSidebar> with search.
+ * Resolves the sidebar element. Custom content is passed through as-is;
+ * when none is given, a default data-driven <ArdoSidebar> is created.
  */
-function wrapSidebarWithSearch(
+function resolveSidebar(
   sidebarContent: ReactNode | undefined,
-  sidebarProps: ArdoSidebarProps | undefined,
-  search: ReactNode | undefined
+  sidebarProps: ArdoSidebarProps | undefined
 ): ReactNode {
   if (sidebarContent == null) {
-    return <ArdoSidebar {...sidebarProps} header={search} />
+    return <ArdoSidebar {...sidebarProps} />
   }
-
-  // If sidebarContent is an ArdoSidebar element, clone it with the search header
-  if (isValidElement<ArdoSidebarProps>(sidebarContent) && sidebarContent.type === ArdoSidebar) {
-    return cloneElement(sidebarContent, {
-      header: sidebarContent.props.header ?? search,
-    })
+  if (isValidElement(sidebarContent)) {
+    return sidebarContent
   }
-
-  // Fallback: wrap custom content in an ArdoSidebar with search
-  return <ArdoSidebar header={search}>{sidebarContent}</ArdoSidebar>
+  return <ArdoSidebar>{sidebarContent}</ArdoSidebar>
 }
 
 function enhanceHeaderWithMobileMenuContent(

--- a/packages/ardo/src/ui/Header.css.ts
+++ b/packages/ardo/src/ui/Header.css.ts
@@ -13,11 +13,6 @@ export const header = style({
   borderBottom: `1px solid ${vars.color.border}`,
   zIndex: 100,
   boxShadow: "0 1px 0 oklch(0 0 0 / 0.02)",
-  "@media": {
-    "(max-width: 1024px)": {
-      height: `calc(${vars.layout.headerHeight} + 2.75rem + env(safe-area-inset-top))`,
-    },
-  },
 })
 
 export const headerContainer = style({
@@ -37,12 +32,28 @@ export const headerLeft = style({
   display: "flex",
   alignItems: "center",
   gap: vars.space.md,
+  flexShrink: 0,
+})
+
+export const headerCenter = style({
+  display: "flex",
+  flex: 1,
+  justifyContent: "center",
+  minWidth: 0,
+  padding: `0 ${vars.space.lg}`,
+  "@media": {
+    "(max-width: 1024px)": {
+      justifyContent: "flex-end",
+      padding: `0 ${vars.space.sm}`,
+    },
+  },
 })
 
 export const headerRight = style({
   display: "flex",
   alignItems: "center",
   gap: "0.75rem",
+  flexShrink: 0,
 })
 
 export const logoLink = style({
@@ -113,41 +124,6 @@ export const desktopNav = style({
       display: "none",
     },
   },
-})
-
-export const mobileNavStrip = style({
-  display: "none",
-  height: "2.75rem",
-  width: "100%",
-  maxWidth: "100vw",
-  overflowX: "auto",
-  overflowY: "hidden",
-  borderTop: `1px solid ${vars.color.borderLight}`,
-  scrollbarWidth: "none",
-  selectors: {
-    "&::-webkit-scrollbar": {
-      display: "none",
-    },
-  },
-  "@media": {
-    "(max-width: 1024px)": {
-      display: "flex",
-      alignItems: "center",
-      padding: `0 ${vars.space.md}`,
-    },
-  },
-})
-
-globalStyle(`${mobileNavStrip} nav`, {
-  display: "flex",
-  alignItems: "center",
-  gap: vars.space.xs,
-  width: "max-content",
-  flexShrink: 0,
-})
-
-globalStyle(`${mobileNavStrip} a, ${mobileNavStrip} span`, {
-  whiteSpace: "nowrap",
 })
 
 // =============================================================================

--- a/packages/ardo/src/ui/Header.tsx
+++ b/packages/ardo/src/ui/Header.tsx
@@ -2,7 +2,7 @@ import { type ReactNode, useEffect, useState } from "react"
 import { Link, useLocation } from "react-router"
 
 import { useArdoConfig } from "../runtime/hooks"
-import { ArdoSearch } from "./components/Search"
+import { ArdoHeaderSearch } from "./components/HeaderSearch"
 import { ArdoThemeToggle } from "./components/ThemeToggle"
 import * as styles from "./Header.css"
 import {
@@ -41,42 +41,47 @@ export type ArdoHeaderProps = {
   className?: string
 }
 
+/**
+ * Mobile menu open state — resets on navigation and locks body scroll
+ * while open.
+ */
+function useMobileMenu(): [boolean, (open: boolean) => void] {
+  const location = useLocation()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    setOpen(false)
+  }, [location.pathname])
+
+  useEffect(() => {
+    document.body.style.overflow = open ? "hidden" : ""
+    return () => {
+      document.body.style.overflow = ""
+    }
+  }, [open])
+
+  return [open, setOpen]
+}
+
 export function ArdoHeader({
   logo,
   title,
   nav,
   actions,
-  search = false,
+  search = true,
   searchPlaceholder,
   themeToggle = true,
   mobileMenuContent,
   className,
 }: ArdoHeaderProps) {
-  const location = useLocation()
   const config = useArdoConfig()
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const [mobileMenuOpen, setMobileMenuOpen] = useMobileMenu()
 
   const resolvedLogo = logo
   const resolvedTitle = title ?? config.title
   const hasLogo = resolvedLogo !== undefined
   const hasTitle = resolvedTitle !== ""
   const hasMobileMenu = mobileMenuContent != null
-
-  useEffect(() => {
-    setMobileMenuOpen(false)
-  }, [location.pathname])
-
-  // Prevent body scroll when mobile menu is open
-  useEffect(() => {
-    if (mobileMenuOpen) {
-      document.body.style.overflow = "hidden"
-    } else {
-      document.body.style.overflow = ""
-    }
-    return () => {
-      document.body.style.overflow = ""
-    }
-  }, [mobileMenuOpen])
 
   return (
     <>
@@ -112,15 +117,18 @@ export function ArdoHeader({
             </Link>
           </div>
 
-          {nav != null && <div className={styles.desktopNav}>{nav}</div>}
+          {search && (
+            <div className={styles.headerCenter}>
+              <ArdoHeaderSearch placeholder={searchPlaceholder} />
+            </div>
+          )}
 
           <div className={styles.headerRight}>
-            {search && <ArdoSearch placeholder={searchPlaceholder} />}
+            {nav != null && <div className={styles.desktopNav}>{nav}</div>}
             {themeToggle && <ArdoThemeToggle />}
             {actions}
           </div>
         </div>
-        {nav != null && <div className={styles.mobileNavStrip}>{nav}</div>}
       </header>
 
       {hasMobileMenu && (

--- a/packages/ardo/src/ui/Layout.css.ts
+++ b/packages/ardo/src/ui/Layout.css.ts
@@ -17,11 +17,6 @@ export const layoutContainer = style({
   width: "100%",
   paddingTop: vars.layout.headerHeight,
   minHeight: 0,
-  "@media": {
-    "(max-width: 1024px)": {
-      paddingTop: `calc(${vars.layout.headerHeight} + 2.75rem)`,
-    },
-  },
 })
 
 export const main = style({

--- a/packages/ardo/src/ui/components/HeaderSearch.css.ts
+++ b/packages/ardo/src/ui/components/HeaderSearch.css.ts
@@ -1,0 +1,87 @@
+import { style } from "@vanilla-extract/css"
+
+import { vars } from "../theme/contract.css"
+
+const MOBILE = "(max-width: 1024px)"
+
+/** Inline search input — desktop only, hidden once the header collapses. */
+export const inline = style({
+  width: "100%",
+  maxWidth: "26rem",
+  "@media": {
+    [MOBILE]: {
+      display: "none",
+    },
+  },
+})
+
+/** Icon button that opens the search overlay — mobile only. */
+export const trigger = style({
+  display: "none",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "2.25rem",
+  height: "2.25rem",
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  borderRadius: vars.radius.base,
+  color: vars.color.text,
+  transition: `background ${vars.transition.fast}`,
+  selectors: {
+    "&:hover": {
+      background: vars.color.bgSoft,
+    },
+  },
+  "@media": {
+    [MOBILE]: {
+      display: "flex",
+    },
+  },
+})
+
+export const overlay = style({
+  position: "fixed",
+  inset: 0,
+  zIndex: 200,
+  display: "flex",
+  flexDirection: "column",
+  background: `color-mix(in oklch, ${vars.color.bg} 88%, transparent)`,
+  backdropFilter: "blur(4px)",
+  WebkitBackdropFilter: "blur(4px)",
+})
+
+export const overlayBar = style({
+  display: "flex",
+  alignItems: "center",
+  gap: vars.space.sm,
+  padding: vars.space.md,
+  borderBottom: `1px solid ${vars.color.border}`,
+  background: vars.color.bg,
+})
+
+export const overlaySearch = style({
+  flex: 1,
+  minWidth: 0,
+})
+
+export const overlayClose = style({
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "2.25rem",
+  height: "2.25rem",
+  flexShrink: 0,
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  borderRadius: vars.radius.base,
+  color: vars.color.textLight,
+  transition: `background ${vars.transition.fast}, color ${vars.transition.fast}`,
+  selectors: {
+    "&:hover": {
+      background: vars.color.bgSoft,
+      color: vars.color.text,
+    },
+  },
+})

--- a/packages/ardo/src/ui/components/HeaderSearch.tsx
+++ b/packages/ardo/src/ui/components/HeaderSearch.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react"
+import { useLocation } from "react-router"
+
+import { SearchIcon, XIcon } from "../icons"
+import * as styles from "./HeaderSearch.css"
+import { ArdoSearch, type ArdoSearchProps } from "./Search"
+
+/**
+ * Header-hosted search. On desktop it renders the search input inline; on
+ * narrow viewports it collapses to an icon button that opens a full-width
+ * search overlay.
+ */
+export function ArdoHeaderSearch({ placeholder }: ArdoSearchProps) {
+  const [overlayOpen, setOverlayOpen] = useState(false)
+  const location = useLocation()
+
+  // Close the overlay on navigation and on Escape.
+  useEffect(() => {
+    setOverlayOpen(false)
+  }, [location.pathname])
+
+  useEffect(() => {
+    if (!overlayOpen) return
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOverlayOpen(false)
+    }
+    document.addEventListener("keydown", handleKey)
+    return () => {
+      document.removeEventListener("keydown", handleKey)
+    }
+  }, [overlayOpen])
+
+  return (
+    <>
+      <div className={styles.inline}>
+        <ArdoSearch placeholder={placeholder} />
+      </div>
+
+      <button
+        type="button"
+        className={styles.trigger}
+        aria-label="Search"
+        onClick={() => {
+          setOverlayOpen(true)
+        }}
+      >
+        <SearchIcon size={20} />
+      </button>
+
+      {overlayOpen && (
+        <div className={styles.overlay}>
+          <div className={styles.overlayBar}>
+            <div className={styles.overlaySearch}>
+              <ArdoSearch placeholder={placeholder} autoFocus />
+            </div>
+            <button
+              type="button"
+              className={styles.overlayClose}
+              aria-label="Close search"
+              onClick={() => {
+                setOverlayOpen(false)
+              }}
+            >
+              <XIcon size={20} />
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/ardo/src/ui/components/Search.tsx
+++ b/packages/ardo/src/ui/components/Search.tsx
@@ -1,5 +1,5 @@
 import MiniSearch from "minisearch"
-import { useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { Link, useNavigate } from "react-router"
 import searchDocs from "virtual:ardo/search-index"
 
@@ -27,6 +27,8 @@ type SearchMatch = {
 export type ArdoSearchProps = {
   /** Placeholder text for the search input (default: "Search...") */
   placeholder?: string
+  /** Focus the input on mount (used by the mobile search overlay). */
+  autoFocus?: boolean
 }
 
 function useSearchIndex() {
@@ -188,13 +190,17 @@ function SearchInput({
   )
 }
 
-export function ArdoSearch({ placeholder = "Search..." }: ArdoSearchProps) {
+export function ArdoSearch({ placeholder = "Search...", autoFocus = false }: ArdoSearchProps) {
   const navigate = useNavigate()
   const containerRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const searchIndex = useSearchIndex()
   const state = useSearch(searchIndex)
   const hasQuery = state.query.trim().length > 0
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus()
+  }, [autoFocus])
 
   useGlobalSearchShortcut(inputRef, state.setIsOpen)
   useOutsideClick({


### PR DESCRIPTION
## Summary

Closes #150.

Search was tucked into the sidebar header. It now lives in the header itself — front and centre — where docs readers expect it (VitePress, Vercel, Tailwind all do this). The header had free space since the top-nav was removed in #153.

## What changed

- **`ArdoHeaderSearch`** (new wrapper): on desktop renders the search input inline in a centered header slot; below 1024px collapses to an icon button that opens a full-width search overlay (autofocus, Escape-to-close, close-on-navigation).
- **`ArdoSearch`** gains an `autoFocus` prop for the overlay.
- **`ArdoHeader`**: search renders in a dedicated centered slot; `search` now defaults to `true`. The mobile nav strip (the second header row) and its layout offset are gone — it only existed for the old top-nav.
- **`ArdoRoot`**: no longer threads search into the sidebar; `resolveSidebar` returns plain sidebar content.

## Verification

Verified on `localhost:5173` (DOM geometry checks — the preview screenshot tool keeps rendering at the wrong scale; the mobile overlay screenshotted fine):

- Desktop (1440px): search input centered in the header (`x≈545–852`), logo left, theme + GitHub right
- Mobile (375px): inline input hidden, search icon button shown; tap opens the overlay with focused input + ⌘K hint + close button; close button and Escape both dismiss it
- Sidebar no longer carries a search field
- `pnpm test` — 47 passing
- `pnpm typecheck`, `pnpm lint` — clean
- `ardo` + `docs` production builds — succeed

## Test plan

- [ ] Desktop — search sits centered in the header, ⌘K focuses it
- [ ] Type a query — popover appears below the input
- [ ] Mobile — search icon opens the overlay, autofocused
- [ ] Overlay — Escape and the X button both close it; navigating closes it
- [ ] No search field remains in the sidebar