### PR TITLE
Spacing polish: heading rhythm, code & card padding

### DIFF
--- a/docs/app/routes/home.css.ts
+++ b/docs/app/routes/home.css.ts
@@ -371,8 +371,8 @@ export const examplesGrid = style({
 export const exampleCard = style({
   display: "flex",
   flexDirection: "column",
-  gap: "10px",
-  padding: "24px",
+  gap: vars.space.smd,
+  padding: vars.space.lg,
   background: softSurface,
   border: `1px solid ${vars.color.borderLight}`,
   borderRadius: vars.radius.lg,

--- a/packages/ardo/src/ui/components/CodeBlock.css.ts
+++ b/packages/ardo/src/ui/components/CodeBlock.css.ts
@@ -19,7 +19,7 @@ export const codeBlock = style({
 })
 
 export const codeTitle = style({
-  padding: `${vars.space.sm} ${vars.space.md}`,
+  padding: `${vars.space.smd} ${vars.space.md}`,
   fontSize: vars.fontSize.xs,
   fontWeight: 500,
   fontFamily: vars.font.mono,
@@ -39,7 +39,7 @@ globalStyle(`${codeWrapper}:hover .${copyButton}, ${codeWrapper}:focus-within .$
 
 globalStyle(`${codeWrapper} pre`, {
   margin: 0,
-  padding: `${vars.space.lg} ${vars.space.md}`,
+  padding: vars.space.md,
   overflowX: "auto",
   fontFamily: vars.font.mono,
   fontSize: vars.fontSize.sm,
@@ -95,7 +95,7 @@ export const lineNumber = style({
 const s = `.${shikiContainerClassName}`
 
 globalStyle(`${s} > [data-title]`, {
-  padding: `${vars.space.sm} ${vars.space.md}`,
+  padding: `${vars.space.smd} ${vars.space.md}`,
   fontSize: vars.fontSize.xs,
   fontWeight: 500,
   fontFamily: vars.font.mono,
@@ -120,7 +120,7 @@ globalStyle(`${s} > [data-lang]`, {
 
 globalStyle(`${s} pre`, {
   margin: 0,
-  padding: `${vars.space.lg} ${vars.space.md}`,
+  padding: vars.space.md,
   overflowX: "auto",
   fontFamily: vars.font.mono,
   fontSize: vars.fontSize.sm,

--- a/packages/ardo/src/ui/components/Container.css.ts
+++ b/packages/ardo/src/ui/components/Container.css.ts
@@ -1,4 +1,4 @@
-import { style } from "@vanilla-extract/css"
+import { globalStyle, style } from "@vanilla-extract/css"
 import { recipe } from "@vanilla-extract/recipes"
 
 import { vars } from "../theme/contract.css"
@@ -86,3 +86,15 @@ export const containerTitle = recipe({
 })
 
 export const containerContent = style({})
+
+// GFM-alert callouts wrap their text in an MDX <p>, which inherits the
+// global content paragraph margin. Collapse the outer margins so the
+// callout's own padding sets the box height; inner gaps between multiple
+// paragraphs are kept.
+globalStyle(`${containerContent} > :first-child`, {
+  marginTop: 0,
+})
+
+globalStyle(`${containerContent} > :last-child`, {
+  marginBottom: 0,
+})

--- a/packages/ardo/src/ui/components/Features.css.ts
+++ b/packages/ardo/src/ui/components/Features.css.ts
@@ -57,7 +57,7 @@ export const featuresContainer = style({
 })
 
 export const feature = style({
-  padding: "28px",
+  padding: vars.space.lg,
   background: vars.color.bg,
   borderRadius: vars.radius.lg,
   border: `1px solid ${vars.color.border}`,

--- a/packages/ardo/src/ui/content.css.ts
+++ b/packages/ardo/src/ui/content.css.ts
@@ -9,7 +9,6 @@ globalStyle(`${c} h1, ${c} h2, ${c} h3, ${c} h4, ${c} h5, ${c} h6`, {
   fontFamily: vars.font.familyHeading,
   fontWeight: 600,
   lineHeight: 1.22,
-  marginTop: vars.space["2xl"],
   marginBottom: vars.space.md,
   letterSpacing: "-0.01em",
   maxWidth: vars.layout.contentMaxWidth,
@@ -22,19 +21,37 @@ globalStyle(`${c} h1`, {
   marginTop: vars.space["2xl"],
 })
 
+// h2 opens a major section — generous separation above.
 globalStyle(`${c} h2`, {
   fontSize: "1.375rem",
-  paddingTop: vars.space.md,
+  marginTop: vars.space["2xl"],
 })
 
+// h3/h4 are subsections — they live inside a section, so they sit closer.
 globalStyle(`${c} h3`, {
   fontSize: vars.fontSize.lg,
   fontWeight: 600,
+  marginTop: vars.space.xl,
 })
 
 globalStyle(`${c} h4`, {
   fontSize: vars.fontSize.sm,
   fontWeight: 600,
+  marginTop: vars.space.lg,
+})
+
+globalStyle(`${c} h5, ${c} h6`, {
+  marginTop: vars.space.lg,
+})
+
+// A heading directly after another heading is part of the same group —
+// drop the section gap so they read as one unit, not two sections.
+globalStyle(`${c} :is(h1,h2,h3,h4,h5,h6) + :is(h2,h3,h4,h5,h6)`, { marginTop: vars.space.sm })
+
+// The first block in the content body sits right under the page title —
+// no leading gap of its own.
+globalStyle(`${c} > :first-child`, {
+  marginTop: 0,
 })
 
 globalStyle(`${c} p`, {

--- a/packages/ardo/src/ui/theme/contract.css.ts
+++ b/packages/ardo/src/ui/theme/contract.css.ts
@@ -93,6 +93,7 @@ export const vars = createGlobalThemeContract(
     space: {
       xs: null,
       sm: null,
+      smd: null,
       md: null,
       lg: null,
       xl: null,

--- a/packages/ardo/src/ui/theme/tokens.ts
+++ b/packages/ardo/src/ui/theme/tokens.ts
@@ -49,6 +49,7 @@ const shared = {
   space: {
     xs: "0.25rem",
     sm: "0.5rem",
+    smd: "0.75rem",
     md: "1rem",
     lg: "1.5rem",
     xl: "2rem",


### PR DESCRIPTION
## Summary

A polishing pass on spacing, guided by the impeccable skill's `layout` /
`spatial-design` references — tighten the heading rhythm, even out padding,
and pull stray values onto the token scale.

## What changed

**Heading rhythm** — every content heading carried a 3rem top margin
(h2 added another 1rem padding on top). Two headings in a row read as two
unrelated sections instead of one group.
- h2 keeps the 3rem section gap; its extra paddingTop is dropped.
- h3 / h4 / h5 / h6 use progressively smaller top margins (2rem / 1.5rem) —
  they are subsections, not full sections.
- A heading directly after another heading drops to a 0.5rem top margin.
- The first block in the content body loses its top margin (sits snug
  under the page title).

**Code-block padding** — was 1.5rem vertical / 1rem horizontal (unbalanced);
now a symmetric 1rem. Code title bar gains slight vertical room (0.5→0.75rem).

**Card padding** — feature cards used a hard-coded 28px, home example cards
24px. Both move to `space.lg` (1.5rem), matching the prev/next cards — one
padding value across every card.

**New token** — `space.smd` (0.75rem) closes the gap between `sm` (0.5rem)
and `md` (1rem); a value the codebase repeatedly hard-coded.

## Verification

Verified on `localhost:5173` (`/guide/markdown`): an adjacent H2→H3 pair
now sits ~16px apart instead of 48px+; standalone headings keep their
section spacing. `pnpm test` (47 passing), typecheck, lint clean; `ardo`
and `docs` builds succeed.

## Out of scope

`Features.css.ts` still has many hard-coded px values beyond the card
padding (section paddings, icon sizes, inner margins). Putting the whole
homepage on the token scale is a broader follow-up, kept out to keep this
diff focused.

## Test plan

- [ ] `/guide/markdown` — consecutive headings sit close, standalone headings keep their gap
- [ ] First heading sits snug under the page title
- [ ] Code blocks — even padding all around
- [ ] Feature / example / prev-next cards share one padding