### PR TITLE
fix: make tabs accessible

### DIFF
--- a/packages/ardo/src/ui/components/Tabs.test.tsx
+++ b/packages/ardo/src/ui/components/Tabs.test.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable import/first -- vi.mock must be hoisted before importing the component. */
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("./Tabs.css", () => ({
+  tab: "tab",
+  tabList: "tabList",
+  tabPanel: "tabPanel",
+  tabPanels: "tabPanels",
+  tabs: "tabs",
+}))
+
+import { ArdoTab, ArdoTabList, ArdoTabPanel, ArdoTabPanels, ArdoTabs } from "./Tabs"
+
+describe("ArdoTabs", () => {
+  it("links explicit tabs and panels with accessible ids", () => {
+    const view = renderToStaticMarkup(
+      <ArdoTabs defaultValue="npm">
+        <ArdoTabList>
+          <ArdoTab value="pnpm">pnpm</ArdoTab>
+          <ArdoTab value="npm">npm</ArdoTab>
+        </ArdoTabList>
+        <ArdoTabPanels>
+          <ArdoTabPanel value="pnpm">pnpm install</ArdoTabPanel>
+          <ArdoTabPanel value="npm">npm install</ArdoTabPanel>
+        </ArdoTabPanels>
+      </ArdoTabs>
+    )
+
+    expect(view).toContain('role="tablist"')
+    expect(view).toContain('aria-selected="false"')
+    expect(view).toContain('aria-selected="true"')
+    expect(view).toContain('tabindex="-1"')
+    expect(view).toContain('tabindex="0"')
+    expect(view).toMatch(/<button[^>]+id="([^"]+)"[^>]+aria-controls="([^"]+)"/u)
+    expect(view).toMatch(/<div[^>]+role="tabpanel"[^>]+id="([^"]+)"[^>]+aria-labelledby="([^"]+)"/u)
+    expect(view).toContain(">npm install</div>")
+    expect(view).not.toContain("pnpm install")
+  })
+
+  it("keeps auto-generated tab values associated by order", () => {
+    const view = renderToStaticMarkup(
+      <ArdoTabs>
+        <ArdoTabList>
+          <ArdoTab>pnpm</ArdoTab>
+          <ArdoTab>npm</ArdoTab>
+        </ArdoTabList>
+        <ArdoTabPanels>
+          <ArdoTabPanel>pnpm install</ArdoTabPanel>
+          <ArdoTabPanel>npm install</ArdoTabPanel>
+        </ArdoTabPanels>
+      </ArdoTabs>
+    )
+
+    const tabControlIds = [...view.matchAll(/aria-controls="([^"]+)"/gu)].map((match) => match[1])
+    const panelIds = [...view.matchAll(/role="tabpanel" id="([^"]+)"/gu)].map((match) => match[1])
+
+    expect(tabControlIds).toHaveLength(2)
+    expect(panelIds).toHaveLength(1)
+    expect(tabControlIds[0]).toBe(panelIds[0])
+    expect(view).toContain(">pnpm install</div>")
+    expect(view).not.toContain(">npm install</div>")
+  })
+})

--- a/packages/ardo/src/ui/components/Tabs.tsx
+++ b/packages/ardo/src/ui/components/Tabs.tsx
@@ -2,8 +2,11 @@ import {
   Children,
   createContext,
   isValidElement,
+  type KeyboardEvent,
   type ReactNode,
   use,
+  useCallback,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -14,7 +17,9 @@ import * as styles from "./Tabs.css"
 type TabsContextValue = {
   activeTab: string
   setActiveTab: (tab: string) => void
+  getPanelId: (value: string) => string
   getTabValue: (value?: string) => string
+  getTabId: (value: string) => string
   getPanelValue: (value?: string) => string
 }
 
@@ -40,6 +45,7 @@ export type ArdoTabsProps = {
  * Tabs container component for organizing content into tabbed panels.
  */
 export function ArdoTabs({ defaultValue, children }: ArdoTabsProps) {
+  const tabsId = useId()
   const [activeTab, setActiveTab] = useState(() => defaultValue ?? findFirstTabValue(children))
   const tabIndexRef = useRef(0)
   const panelIndexRef = useRef(0)
@@ -47,21 +53,36 @@ export function ArdoTabs({ defaultValue, children }: ArdoTabsProps) {
   tabIndexRef.current = 0
   panelIndexRef.current = 0
 
-  const getTabValue = (value?: string) => {
+  const getTabValue = useCallback((value?: string) => {
     const index = tabIndexRef.current++
     return value ?? `${AUTO_TAB_PREFIX}${index}`
-  }
+  }, [])
 
-  const getPanelValue = (value?: string) => {
+  const getPanelValue = useCallback((value?: string) => {
     const index = panelIndexRef.current++
     return value ?? `${AUTO_TAB_PREFIX}${index}`
-  }
+  }, [])
 
   const effectiveTab = defaultValue ?? activeTab
+  const getTabId = useCallback(
+    (value: string) => `${tabsId}-tab-${toDomIdSegment(value)}`,
+    [tabsId]
+  )
+  const getPanelId = useCallback(
+    (value: string) => `${tabsId}-panel-${toDomIdSegment(value)}`,
+    [tabsId]
+  )
 
   const contextValue = useMemo(
-    () => ({ activeTab: effectiveTab, setActiveTab, getTabValue, getPanelValue }),
-    [effectiveTab]
+    () => ({
+      activeTab: effectiveTab,
+      setActiveTab,
+      getPanelId,
+      getPanelValue,
+      getTabId,
+      getTabValue,
+    }),
+    [effectiveTab, getPanelId, getPanelValue, getTabId, getTabValue]
   )
 
   return (
@@ -81,7 +102,7 @@ export type ArdoTabListProps = {
  */
 export function ArdoTabList({ children }: ArdoTabListProps) {
   return (
-    <div className={styles.tabList} role="tablist">
+    <div className={styles.tabList} role="tablist" onKeyDown={handleTabListKeyDown}>
       {children}
     </div>
   )
@@ -98,7 +119,7 @@ export type ArdoTabProps = {
  * Individual tab button.
  */
 export function ArdoTab({ value, children }: ArdoTabProps) {
-  const { activeTab, setActiveTab, getTabValue } = useTabsContext()
+  const { activeTab, setActiveTab, getPanelId, getTabId, getTabValue } = useTabsContext()
   const resolvedValue = getTabValue(value)
   const isActive = activeTab === resolvedValue
 
@@ -106,7 +127,11 @@ export function ArdoTab({ value, children }: ArdoTabProps) {
     <button
       type="button"
       role="tab"
+      id={getTabId(resolvedValue)}
+      aria-controls={getPanelId(resolvedValue)}
       aria-selected={isActive}
+      tabIndex={isActive ? 0 : -1}
+      data-ardo-tab-value={resolvedValue}
       className={[styles.tab, isActive && "active"].filter(Boolean).join(" ")}
       onClick={() => {
         setActiveTab(resolvedValue)
@@ -128,7 +153,7 @@ export type ArdoTabPanelProps = {
  * Content panel for a tab.
  */
 export function ArdoTabPanel({ value, children }: ArdoTabPanelProps) {
-  const { activeTab, getPanelValue } = useTabsContext()
+  const { activeTab, getPanelId, getPanelValue, getTabId } = useTabsContext()
   const resolvedValue = getPanelValue(value)
   const isActive = activeTab === resolvedValue
 
@@ -137,7 +162,13 @@ export function ArdoTabPanel({ value, children }: ArdoTabPanelProps) {
   }
 
   return (
-    <div role="tabpanel" className={styles.tabPanel}>
+    <div
+      role="tabpanel"
+      id={getPanelId(resolvedValue)}
+      aria-labelledby={getTabId(resolvedValue)}
+      tabIndex={0}
+      className={styles.tabPanel}
+    >
       {children}
     </div>
   )
@@ -182,4 +213,56 @@ function getFirstTabValueFromChild(child: ReactNode): null | string {
 
   const nestedValue = findFirstTabValue(nestedChildren)
   return nestedValue === "" ? null : nestedValue
+}
+
+function handleTabListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+  if (!isTabNavigationKey(event.key)) {
+    return
+  }
+
+  const tabs = getTabsFromList(event.currentTarget)
+  if (tabs.length === 0) {
+    return
+  }
+
+  if (!(event.target instanceof HTMLButtonElement)) {
+    return
+  }
+
+  const currentIndex = tabs.indexOf(event.target)
+  if (currentIndex === -1) {
+    return
+  }
+
+  event.preventDefault()
+  const nextTab = tabs[getNextTabIndex(event.key, currentIndex, tabs.length)]
+  nextTab.focus()
+  nextTab.click()
+}
+
+function isTabNavigationKey(key: string) {
+  return key === "ArrowLeft" || key === "ArrowRight" || key === "Home" || key === "End"
+}
+
+function getTabsFromList(tabList: HTMLDivElement) {
+  return [...tabList.querySelectorAll<HTMLButtonElement>('[role="tab"]')]
+}
+
+function getNextTabIndex(key: string, currentIndex: number, tabCount: number) {
+  switch (key) {
+    case "ArrowLeft":
+      return (currentIndex - 1 + tabCount) % tabCount
+    case "ArrowRight":
+      return (currentIndex + 1) % tabCount
+    case "Home":
+      return 0
+    case "End":
+      return tabCount - 1
+    default:
+      return currentIndex
+  }
+}
+
+function toDomIdSegment(value: string) {
+  return Array.from(value, (char) => char.charCodeAt(0).toString(36)).join("-")
 }


### PR DESCRIPTION
## Description

Adds the missing accessibility wiring for `ArdoTabs`:

- links tabs and panels with stable `id`, `aria-controls`, and `aria-labelledby` attributes
- exposes the active tab with `aria-selected` and a roving `tabIndex`
- supports `ArrowLeft`, `ArrowRight`, `Home`, and `End` keyboard navigation
- covers explicit tab values and order-based generated values with regression tests

Closes #174

## Motivation and Context

Tabs previously rendered the basic `tablist`, `tab`, and `tabpanel` roles but did not expose the relationships or keyboard behavior expected by assistive technologies and keyboard users.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm format` and `pnpm lint`
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] I have updated the documentation (if applicable)
- [ ] All existing tests pass (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validation run:

- `pnpm exec prettier --write packages/ardo/src/ui/components/Tabs.tsx packages/ardo/src/ui/components/Tabs.test.tsx`
- `CI=true pnpm exec vitest --run packages/ardo/src/ui/components/Tabs.test.tsx`
- `CI=true pnpm typecheck`
- `CI=true pnpm lint`

`pnpm lint` passes with the repository's existing warning set.
