### PR TITLE
fix: expose search as accessible combobox

### DIFF
--- a/packages/ardo/src/ui/components/Search.tsx
+++ b/packages/ardo/src/ui/components/Search.tsx
@@ -1,25 +1,19 @@
 import MiniSearch from "minisearch"
-import { useEffect, useMemo, useRef, useState } from "react"
-import { Link, useNavigate } from "react-router"
+import { useEffect, useId, useMemo, useRef, useState } from "react"
+import { useNavigate } from "react-router"
 import searchDocs from "virtual:ardo/search-index"
 
 import { SearchIcon } from "../icons"
-import { ArdoOwlMark } from "../OwlMark"
+import { getActiveSearchOptionId, getSearchKeyboardAction, getSearchOptionId } from "./search-a11y"
 import { useGlobalSearchShortcut, useOutsideClick } from "./search-hooks"
 import * as styles from "./Search.css"
 import { SearchPopover } from "./SearchPopover"
+import { type SearchMatch, SearchResults } from "./SearchResults"
 
 type SearchDoc = {
   id: string
   title: string
   content: string
-  path: string
-  section?: string
-}
-
-type SearchMatch = {
-  id: string
-  title: string
   path: string
   section?: string
 }
@@ -59,59 +53,6 @@ function normalizeResults(rawResults: Array<Record<string, unknown>>): SearchMat
   })
 }
 
-function SearchResults({
-  results,
-  selectedIndex,
-  query,
-  onClose,
-}: {
-  results: SearchMatch[]
-  selectedIndex: number
-  query: string
-  onClose: () => void
-}) {
-  return (
-    <>
-      {results.length > 0 ? (
-        <ul className={styles.searchResults}>
-          {results.map((result, index) => (
-            <li key={result.id}>
-              <Link
-                to={result.path}
-                className={[styles.searchResult, index === selectedIndex && "selected"]
-                  .filter(Boolean)
-                  .join(" ")}
-                onClick={onClose}
-              >
-                <span className={styles.searchResultTitle}>{result.title}</span>
-                {result.section !== undefined && (
-                  <span className={styles.searchResultSection}>{result.section}</span>
-                )}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <div className={styles.searchNoResults}>
-          <ArdoOwlMark size={36} className={styles.searchNoResultsOwl} title="" />
-          <span>No results found for &quot;{query}&quot;</span>
-        </div>
-      )}
-      <div className={styles.searchFooter}>
-        <span>
-          <kbd>↑</kbd> <kbd>↓</kbd> to navigate
-        </span>
-        <span>
-          <kbd>↵</kbd> to select
-        </span>
-        <span>
-          <kbd>esc</kbd> to close
-        </span>
-      </div>
-    </>
-  )
-}
-
 function useSearch(searchIndex: ReturnType<typeof useSearchIndex>) {
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQuery] = useState("")
@@ -143,6 +84,9 @@ function SearchInput({
   onSearch,
   onKeyDown,
   onFocus,
+  activeOptionId,
+  expanded,
+  listboxId,
 }: {
   inputRef: React.RefObject<HTMLInputElement | null>
   placeholder: string
@@ -151,6 +95,9 @@ function SearchInput({
   onSearch: (q: string) => void
   onKeyDown: (e: React.KeyboardEvent) => void
   onFocus: () => void
+  activeOptionId?: string
+  expanded: boolean
+  listboxId: string
 }) {
   return (
     <div className={styles.searchField}>
@@ -167,6 +114,12 @@ function SearchInput({
         onKeyDown={onKeyDown}
         onFocus={onFocus}
         aria-label="Search"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={expanded}
+        aria-controls={listboxId}
+        aria-activedescendant={activeOptionId}
+        aria-haspopup="listbox"
       />
       {hasQuery && (
         <button
@@ -190,6 +143,29 @@ function SearchInput({
   )
 }
 
+function useSearchA11y({
+  expanded,
+  results,
+  selectedIndex,
+}: {
+  expanded: boolean
+  results: SearchMatch[]
+  selectedIndex: number
+}) {
+  const searchId = useId()
+  const listboxId = `${searchId}-results`
+  const getOptionId = (resultId: string, index: number) =>
+    getSearchOptionId(listboxId, resultId, index)
+  const activeOptionId = getActiveSearchOptionId({
+    getOptionId,
+    isOpen: expanded,
+    results,
+    selectedIndex,
+  })
+
+  return { activeOptionId, getOptionId, listboxId }
+}
+
 export function ArdoSearch({ placeholder = "Search...", autoFocus = false }: ArdoSearchProps) {
   const navigate = useNavigate()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -197,6 +173,12 @@ export function ArdoSearch({ placeholder = "Search...", autoFocus = false }: Ard
   const searchIndex = useSearchIndex()
   const state = useSearch(searchIndex)
   const hasQuery = state.query.trim().length > 0
+  const expanded = state.isOpen && hasQuery
+  const searchA11y = useSearchA11y({
+    expanded,
+    results: state.results,
+    selectedIndex: state.selectedIndex,
+  })
 
   useEffect(() => {
     if (autoFocus) inputRef.current?.focus()
@@ -211,33 +193,29 @@ export function ArdoSearch({ placeholder = "Search...", autoFocus = false }: Ard
   })
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    switch (e.key) {
-      case "ArrowDown":
-        if (state.results.length > 0) {
+    const action = getSearchKeyboardAction({
+      key: e.key,
+      results: state.results,
+      selectedIndex: state.selectedIndex,
+    })
+
+    switch (action.type) {
+      case "select-index":
+        if (state.isOpen) {
           e.preventDefault()
-          state.setSelectedIndex((p) => Math.min(p + 1, state.results.length - 1))
+          state.setSelectedIndex(action.index)
         }
         break
-      case "ArrowUp":
-        if (state.results.length > 0) {
-          e.preventDefault()
-          state.setSelectedIndex((p) => Math.max(p - 1, 0))
-        }
+      case "navigate":
+        e.preventDefault()
+        void navigate(action.path)
+        state.setIsOpen(false)
         break
-      case "Enter": {
-        const p = state.results[state.selectedIndex]?.path
-        if (typeof p === "string") {
-          e.preventDefault()
-          void navigate(p)
-          state.setIsOpen(false)
-        }
-        break
-      }
-      case "Escape":
+      case "close":
         state.setIsOpen(false)
         inputRef.current?.blur()
         break
-      default:
+      case "none":
         break
     }
   }
@@ -246,7 +224,7 @@ export function ArdoSearch({ placeholder = "Search...", autoFocus = false }: Ard
     <div
       className={styles.search}
       ref={containerRef}
-      data-expanded={state.isOpen || hasQuery ? "true" : "false"}
+      data-expanded={expanded ? "true" : "false"}
       onMouseDown={() => inputRef.current?.focus()}
     >
       <SearchInput
@@ -259,10 +237,15 @@ export function ArdoSearch({ placeholder = "Search...", autoFocus = false }: Ard
         onFocus={() => {
           if (hasQuery) state.setIsOpen(true)
         }}
+        activeOptionId={searchA11y.activeOptionId}
+        expanded={expanded}
+        listboxId={searchA11y.listboxId}
       />
-      {state.isOpen && hasQuery && (
+      {expanded && (
         <SearchPopover anchorRef={containerRef}>
           <SearchResults
+            getOptionId={searchA11y.getOptionId}
+            listboxId={searchA11y.listboxId}
             results={state.results}
             selectedIndex={state.selectedIndex}
             query={state.query}

--- a/packages/ardo/src/ui/components/SearchResults.tsx
+++ b/packages/ardo/src/ui/components/SearchResults.tsx
@@ -1,0 +1,78 @@
+import { Link } from "react-router"
+
+import { ArdoOwlMark } from "../OwlMark"
+import * as styles from "./Search.css"
+
+export type SearchMatch = {
+  id: string
+  title: string
+  path: string
+  section?: string
+}
+
+export function SearchResults({
+  getOptionId,
+  listboxId,
+  results,
+  selectedIndex,
+  query,
+  onClose,
+}: {
+  getOptionId: (resultId: string, index: number) => string
+  listboxId: string
+  results: SearchMatch[]
+  selectedIndex: number
+  query: string
+  onClose: () => void
+}) {
+  return (
+    <>
+      {results.length > 0 ? (
+        <ul
+          id={listboxId}
+          className={styles.searchResults}
+          role="listbox"
+          aria-label="Search results"
+        >
+          {results.map((result, index) => (
+            <li key={result.id} role="presentation">
+              <Link
+                id={getOptionId(result.id, index)}
+                to={result.path}
+                role="option"
+                aria-selected={index === selectedIndex}
+                className={[styles.searchResult, index === selectedIndex && "selected"]
+                  .filter(Boolean)
+                  .join(" ")}
+                onClick={onClose}
+              >
+                <span className={styles.searchResultTitle}>{result.title}</span>
+                {result.section !== undefined && (
+                  <span className={styles.searchResultSection}>{result.section}</span>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div id={listboxId} role="listbox" aria-label="Search results">
+          <div className={styles.searchNoResults} role="status" aria-live="polite">
+            <ArdoOwlMark size={36} className={styles.searchNoResultsOwl} title="" />
+            <span>No results found for &quot;{query}&quot;</span>
+          </div>
+        </div>
+      )}
+      <div className={styles.searchFooter}>
+        <span>
+          <kbd>↑</kbd> <kbd>↓</kbd> to navigate
+        </span>
+        <span>
+          <kbd>↵</kbd> to select
+        </span>
+        <span>
+          <kbd>esc</kbd> to close
+        </span>
+      </div>
+    </>
+  )
+}

--- a/packages/ardo/src/ui/components/search-a11y.test.ts
+++ b/packages/ardo/src/ui/components/search-a11y.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import { getActiveSearchOptionId, getSearchKeyboardAction, getSearchOptionId } from "./search-a11y"
+
+describe("search accessibility helpers", () => {
+  const results = [{ path: "/intro" }, { path: "/api" }, { path: "/config" }]
+
+  it("moves the active option with arrow keys and clamps to available results", () => {
+    expect(getSearchKeyboardAction({ key: "ArrowDown", results, selectedIndex: 0 })).toStrictEqual({
+      type: "select-index",
+      index: 1,
+    })
+    expect(getSearchKeyboardAction({ key: "ArrowDown", results, selectedIndex: 2 })).toStrictEqual({
+      type: "select-index",
+      index: 2,
+    })
+    expect(getSearchKeyboardAction({ key: "ArrowUp", results, selectedIndex: 2 })).toStrictEqual({
+      type: "select-index",
+      index: 1,
+    })
+    expect(getSearchKeyboardAction({ key: "ArrowUp", results, selectedIndex: 0 })).toStrictEqual({
+      type: "select-index",
+      index: 0,
+    })
+  })
+
+  it("maps Enter, Escape, and unrelated keys to explicit actions", () => {
+    expect(getSearchKeyboardAction({ key: "Enter", results, selectedIndex: 1 })).toStrictEqual({
+      type: "navigate",
+      path: "/api",
+    })
+    expect(getSearchKeyboardAction({ key: "Enter", results: [], selectedIndex: 0 })).toStrictEqual({
+      type: "none",
+    })
+    expect(getSearchKeyboardAction({ key: "Escape", results, selectedIndex: 1 })).toStrictEqual({
+      type: "close",
+    })
+    expect(getSearchKeyboardAction({ key: "Tab", results, selectedIndex: 1 })).toStrictEqual({
+      type: "none",
+    })
+  })
+
+  it("builds stable option ids and exposes an active descendant only while open", () => {
+    const optionId = getSearchOptionId("search-results", "guide/config", 1)
+    expect(optionId).toBe("search-results-option-2v-39-2x-2s-2t-1b-2r-33-32-2u-2x-2v-1")
+
+    expect(
+      getActiveSearchOptionId({
+        getOptionId: (id, index) => getSearchOptionId("search-results", id, index),
+        isOpen: true,
+        results: [{ id: "intro" }, { id: "guide/config" }],
+        selectedIndex: 1,
+      })
+    ).toBe(optionId)
+
+    expect(
+      getActiveSearchOptionId({
+        getOptionId: (id, index) => getSearchOptionId("search-results", id, index),
+        isOpen: false,
+        results: [{ id: "intro" }],
+        selectedIndex: 0,
+      })
+    ).toBeUndefined()
+  })
+})

--- a/packages/ardo/src/ui/components/search-a11y.ts
+++ b/packages/ardo/src/ui/components/search-a11y.ts
@@ -1,0 +1,79 @@
+export type SearchKeyboardAction =
+  | { index: number; type: "select-index" }
+  | { path: string; type: "navigate" }
+  | { type: "close" }
+  | { type: "none" }
+
+export type SearchKeyboardResult = {
+  path: string
+}
+
+export function getSearchOptionId(listboxId: string, resultId: string, index: number) {
+  return `${listboxId}-option-${toDomIdSegment(resultId)}-${index}`
+}
+
+export function getActiveSearchOptionId({
+  getOptionId,
+  isOpen,
+  results,
+  selectedIndex,
+}: {
+  getOptionId: (resultId: string, index: number) => string
+  isOpen: boolean
+  results: Array<{ id: string }>
+  selectedIndex: number
+}): string | undefined {
+  if (!isOpen || results.length === 0) {
+    return
+  }
+
+  const selectedResult = getResultAtIndex(results, selectedIndex)
+  if (selectedResult == null) {
+    return
+  }
+
+  return getOptionId(selectedResult.id, selectedIndex)
+}
+
+export function getSearchKeyboardAction({
+  key,
+  results,
+  selectedIndex,
+}: {
+  key: string
+  results: SearchKeyboardResult[]
+  selectedIndex: number
+}): SearchKeyboardAction {
+  switch (key) {
+    case "ArrowDown":
+      return results.length > 0
+        ? { type: "select-index", index: Math.min(selectedIndex + 1, results.length - 1) }
+        : { type: "none" }
+    case "ArrowUp":
+      return results.length > 0
+        ? { type: "select-index", index: Math.max(selectedIndex - 1, 0) }
+        : { type: "none" }
+    case "Enter": {
+      const selectedResult = getResultAtIndex(results, selectedIndex)
+      return selectedResult == null
+        ? { type: "none" }
+        : { type: "navigate", path: selectedResult.path }
+    }
+    case "Escape":
+      return { type: "close" }
+    default:
+      return { type: "none" }
+  }
+}
+
+function toDomIdSegment(value: string) {
+  return Array.from(value, (char) => char.charCodeAt(0).toString(36)).join("-")
+}
+
+function getResultAtIndex<T>(results: T[], selectedIndex: number) {
+  if (selectedIndex < 0 || selectedIndex >= results.length) {
+    return
+  }
+
+  return results[selectedIndex]
+}


### PR DESCRIPTION
## Description

Exposes `ArdoSearch` as an accessible combobox/listbox interaction:

- adds `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-activedescendant`, and `aria-haspopup="listbox"` to the search input
- gives the portaled results a stable listbox ID
- renders search results as selectable options with stable IDs and `aria-selected`
- preserves ArrowUp, ArrowDown, Enter, Escape, mouse selection, and outside-click behavior
- extracts result rendering and keyboard/active-option helpers with regression coverage

Closes #175

## Motivation and Context

Search is a core docs navigation path. The previous UI had keyboard behavior but did not expose the popup state, active option, or selected result semantics to assistive technologies.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm format` and `pnpm lint`
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] I have updated the documentation (if applicable)
- [ ] All existing tests pass (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validation run:

- `pnpm exec prettier --write packages/ardo/src/ui/components/Search.tsx packages/ardo/src/ui/components/SearchResults.tsx packages/ardo/src/ui/components/search-a11y.ts packages/ardo/src/ui/components/search-a11y.test.ts`
- `CI=true pnpm exec vitest --run packages/ardo/src/ui/components/search-a11y.test.ts`
- `CI=true pnpm typecheck`
- `CI=true pnpm lint`

`pnpm lint` passes with the repository's existing warning set.
