### PR TITLE
fix: make mobile drawer modal-safe

### DIFF
--- a/packages/ardo/src/ui/Header.tsx
+++ b/packages/ardo/src/ui/Header.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useState } from "react"
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react"
 import { Link, useLocation } from "react-router"
 
 import { useArdoConfig } from "../runtime/hooks"
@@ -11,9 +11,9 @@ import {
   MessageCircleIcon,
   NpmIcon,
   TwitterIcon,
-  XIcon,
   YoutubeIcon,
 } from "./icons"
+import { MobileSlidePanel } from "./MobileSlidePanel"
 import * as navStyles from "./Nav.css"
 
 // =============================================================================
@@ -76,12 +76,16 @@ export function ArdoHeader({
 }: ArdoHeaderProps) {
   const config = useArdoConfig()
   const [mobileMenuOpen, setMobileMenuOpen] = useMobileMenu()
+  const mobileMenuButtonRef = useRef<HTMLButtonElement>(null)
 
   const resolvedLogo = logo
   const resolvedTitle = title ?? config.title
   const hasLogo = resolvedLogo !== undefined
   const hasTitle = resolvedTitle !== ""
   const hasMobileMenu = mobileMenuContent != null
+  const closeMobileMenu = useCallback(() => {
+    setMobileMenuOpen(false)
+  }, [setMobileMenuOpen])
 
   return (
     <>
@@ -90,6 +94,7 @@ export function ArdoHeader({
           <div className={styles.headerLeft}>
             {hasMobileMenu && (
               <button
+                ref={mobileMenuButtonRef}
                 type="button"
                 className={styles.mobileMenuButton}
                 onClick={() => {
@@ -131,97 +136,20 @@ export function ArdoHeader({
         </div>
       </header>
 
-      {hasMobileMenu && (
+      {hasMobileMenu && mobileMenuOpen && (
         <MobileSlidePanel
-          isOpen={mobileMenuOpen}
           logo={resolvedLogo}
           title={resolvedTitle}
           nav={nav}
           themeToggle={themeToggle}
-          onClose={() => {
-            setMobileMenuOpen(false)
-          }}
+          triggerRef={mobileMenuButtonRef}
+          onClose={closeMobileMenu}
         >
           {mobileMenuContent}
         </MobileSlidePanel>
       )}
     </>
   )
-}
-
-// =============================================================================
-// Mobile Slide-in Panel
-// =============================================================================
-
-function MobileSlidePanel({
-  isOpen,
-  logo,
-  title,
-  nav,
-  themeToggle,
-  children,
-  onClose,
-}: {
-  isOpen: boolean
-  logo?: { light: string; dark: string } | string
-  title: string
-  nav?: ReactNode
-  themeToggle?: boolean
-  children: ReactNode
-  onClose: () => void
-}) {
-  return (
-    <>
-      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
-      <div className={styles.mobileBackdrop} data-open={isOpen} onClick={onClose} />
-
-      {/* Panel */}
-      <div className={styles.mobilePanel} data-open={isOpen} aria-hidden={!isOpen}>
-        <div className={styles.mobilePanelHeader}>
-          <Link to="/" className={styles.logoLink} onClick={onClose}>
-            {logo != null && (
-              <img
-                src={typeof logo === "string" ? logo : logo.light}
-                alt={title}
-                className={styles.logo}
-              />
-            )}
-          </Link>
-          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-            {themeToggle && <ArdoThemeToggle />}
-            <button
-              type="button"
-              className={styles.mobilePanelClose}
-              onClick={onClose}
-              aria-label="Close menu"
-            >
-              <XIcon size={20} />
-            </button>
-          </div>
-        </div>
-
-        {/* Nav links */}
-        {nav != null && (
-          <div className={styles.mobilePanelNav} onClickCapture={handleLinkClick(onClose)}>
-            {nav}
-          </div>
-        )}
-
-        {/* Sidebar content - wrapper overrides display:none from sidebar CSS */}
-        <div className={styles.mobilePanelSidebar} onClickCapture={handleLinkClick(onClose)}>
-          {children}
-        </div>
-      </div>
-    </>
-  )
-}
-
-function handleLinkClick(onClose: () => void) {
-  return (event: React.MouseEvent<HTMLElement>) => {
-    if (event.target instanceof HTMLElement && event.target.closest("a") !== null) {
-      onClose()
-    }
-  }
 }
 
 // =============================================================================

--- a/packages/ardo/src/ui/MobileSlidePanel.tsx
+++ b/packages/ardo/src/ui/MobileSlidePanel.tsx
@@ -1,0 +1,164 @@
+import { type MouseEvent, type ReactNode, type RefObject, useEffect, useRef } from "react"
+import { Link } from "react-router"
+
+import { ArdoThemeToggle } from "./components/ThemeToggle"
+import * as styles from "./Header.css"
+import { XIcon } from "./icons"
+import { getTrappedFocusTarget } from "./mobile-drawer-a11y"
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",")
+
+export function MobileSlidePanel({
+  logo,
+  title,
+  nav,
+  themeToggle,
+  triggerRef,
+  children,
+  onClose,
+}: {
+  logo?: { light: string; dark: string } | string
+  title: string
+  nav?: ReactNode
+  themeToggle?: boolean
+  triggerRef: RefObject<HTMLButtonElement | null>
+  children: ReactNode
+  onClose: () => void
+}) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useMobilePanelFocus({ onClose, panelRef, triggerRef })
+
+  return (
+    <>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
+      <div className={styles.mobileBackdrop} data-open="true" onClick={onClose} />
+
+      <div
+        ref={panelRef}
+        className={styles.mobilePanel}
+        data-open="true"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title === "" ? "Navigation menu" : `${title} navigation menu`}
+        tabIndex={-1}
+      >
+        <div className={styles.mobilePanelHeader}>
+          <Link to="/" className={styles.logoLink} onClick={onClose}>
+            {logo != null && (
+              <img
+                src={typeof logo === "string" ? logo : logo.light}
+                alt={title}
+                className={styles.logo}
+              />
+            )}
+          </Link>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            {themeToggle && <ArdoThemeToggle />}
+            <button
+              type="button"
+              className={styles.mobilePanelClose}
+              onClick={onClose}
+              aria-label="Close menu"
+            >
+              <XIcon size={20} />
+            </button>
+          </div>
+        </div>
+
+        {nav != null && (
+          <div className={styles.mobilePanelNav} onClickCapture={handleLinkClick(onClose)}>
+            {nav}
+          </div>
+        )}
+
+        <div className={styles.mobilePanelSidebar} onClickCapture={handleLinkClick(onClose)}>
+          {children}
+        </div>
+      </div>
+    </>
+  )
+}
+
+function useMobilePanelFocus({
+  onClose,
+  panelRef,
+  triggerRef,
+}: {
+  onClose: () => void
+  panelRef: RefObject<HTMLDivElement | null>
+  triggerRef: RefObject<HTMLButtonElement | null>
+}) {
+  useEffect(() => {
+    const panel = panelRef.current
+    if (panel == null) {
+      return
+    }
+    const triggerElement = triggerRef.current
+
+    focusInitialPanelElement(panel)
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault()
+        onClose()
+        return
+      }
+
+      if (event.key === "Tab") {
+        trapPanelFocus(event, panel)
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown)
+      triggerElement?.focus()
+    }
+  }, [onClose, panelRef, triggerRef])
+}
+
+function focusInitialPanelElement(panel: HTMLDivElement) {
+  const focusableElements = getFocusablePanelElements(panel)
+  const initialFocusTarget = focusableElements[0] ?? panel
+  initialFocusTarget.focus()
+}
+
+function trapPanelFocus(event: KeyboardEvent, panel: HTMLDivElement) {
+  const focusableElements = getFocusablePanelElements(panel)
+  const activeElement =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null
+  const target = getTrappedFocusTarget({
+    activeElement,
+    focusableElements,
+    shiftKey: event.shiftKey,
+  })
+
+  if (target == null) {
+    return
+  }
+
+  event.preventDefault()
+  target.focus()
+}
+
+function getFocusablePanelElements(panel: HTMLDivElement) {
+  return [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
+    (element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true"
+  )
+}
+
+function handleLinkClick(onClose: () => void) {
+  return (event: MouseEvent<HTMLElement>) => {
+    if (event.target instanceof HTMLElement && event.target.closest("a") !== null) {
+      onClose()
+    }
+  }
+}

--- a/packages/ardo/src/ui/mobile-drawer-a11y.test.ts
+++ b/packages/ardo/src/ui/mobile-drawer-a11y.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { getTrappedFocusTarget } from "./mobile-drawer-a11y"
+
+describe("mobile drawer accessibility helpers", () => {
+  const focusableElements = ["close", "link", "theme"]
+
+  it("wraps focus from the last element to the first element on Tab", () => {
+    expect(
+      getTrappedFocusTarget({
+        activeElement: "theme",
+        focusableElements,
+        shiftKey: false,
+      })
+    ).toBe("close")
+  })
+
+  it("wraps focus from the first element to the last element on Shift+Tab", () => {
+    expect(
+      getTrappedFocusTarget({
+        activeElement: "close",
+        focusableElements,
+        shiftKey: true,
+      })
+    ).toBe("theme")
+  })
+
+  it("does not trap when focus is already inside the drawer bounds", () => {
+    expect(
+      getTrappedFocusTarget({
+        activeElement: "link",
+        focusableElements,
+        shiftKey: false,
+      })
+    ).toBeUndefined()
+  })
+})

--- a/packages/ardo/src/ui/mobile-drawer-a11y.ts
+++ b/packages/ardo/src/ui/mobile-drawer-a11y.ts
@@ -1,0 +1,24 @@
+export function getTrappedFocusTarget<T>({
+  activeElement,
+  focusableElements,
+  shiftKey,
+}: {
+  activeElement: null | T
+  focusableElements: T[]
+  shiftKey: boolean
+}): T | undefined {
+  const firstElement = focusableElements[0]
+  const lastElement = focusableElements.at(-1)
+
+  if (firstElement == null || lastElement == null) {
+    return
+  }
+
+  if (shiftKey && activeElement === firstElement) {
+    return lastElement
+  }
+
+  if (!shiftKey && activeElement === lastElement) {
+    return firstElement
+  }
+}


### PR DESCRIPTION
## Description

Makes the mobile navigation drawer modal-safe:

- unmounts the drawer while closed so hidden links and controls are not keyboard reachable
- moves the drawer into a dedicated `MobileSlidePanel` component
- exposes the open drawer as a labelled modal dialog with `role="dialog"` and `aria-modal="true"`
- moves focus into the drawer on open and restores focus to the trigger button on close
- closes on Escape and keeps focus trapped inside the open drawer
- preserves backdrop close, link close, route-change close, and body scroll locking behavior

Closes #176

## Motivation and Context

The mobile drawer previously stayed mounted with `aria-hidden` while visually translated off-screen, leaving focus management ambiguous for keyboard and screen reader users.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm format` and `pnpm lint`
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] I have updated the documentation (if applicable)
- [ ] All existing tests pass (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validation run:

- `pnpm exec prettier --write packages/ardo/src/ui/Header.tsx packages/ardo/src/ui/MobileSlidePanel.tsx packages/ardo/src/ui/mobile-drawer-a11y.ts packages/ardo/src/ui/mobile-drawer-a11y.test.ts`
- `CI=true pnpm exec vitest --run packages/ardo/src/ui/mobile-drawer-a11y.test.ts`
- `CI=true pnpm typecheck`
- `CI=true pnpm lint`

`pnpm lint` passes with the repository's existing warning set.
