### PR TITLE
fix: harden footer HTML rendering

### DIFF
--- a/docs/app/routes/guide/custom-theme.mdx
+++ b/docs/app/routes/guide/custom-theme.mdx
@@ -188,6 +188,10 @@ export function Layout({ children }) {
 }
 ```
 
+Footer `message` and `copyright` props render as React content, so plain strings are escaped. If you
+need footer markup from a trusted source, use `trustedMessageHtml` or `trustedCopyrightHtml`; do not
+pass user- or CMS-provided content to those props.
+
 ## Runtime Hooks
 
 When building custom components, you'll need access to site configuration, sidebar data, and page metadata. Ardo provides React hooks for all of it:

--- a/packages/ardo/src/ui/Footer.test.tsx
+++ b/packages/ardo/src/ui/Footer.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { ArdoProvider } from "../runtime/hooks"
+import { ArdoFooter } from "./Footer"
+
+function renderFooter(node: React.ReactNode): string {
+  return renderToStaticMarkup(
+    <ArdoProvider config={{ title: "Docs" }} sidebar={[]}>
+      {node}
+    </ArdoProvider>
+  )
+}
+
+describe("ArdoFooter", () => {
+  it("escapes plain string footer content", () => {
+    const view = renderFooter(
+      <ArdoFooter
+        ardoLink={false}
+        message="<strong>Released</strong>"
+        copyright="<script>alert('x')</script>"
+      />
+    )
+
+    expect(view).toContain("&lt;strong&gt;Released&lt;/strong&gt;")
+    expect(view).toContain("&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;")
+    expect(view).not.toContain("<strong>Released</strong>")
+    expect(view).not.toContain("<script>")
+  })
+
+  it("renders trusted HTML only through explicit trusted props", () => {
+    const view = renderFooter(
+      <ArdoFooter
+        ardoLink={false}
+        trustedMessageHtml="<strong>Released</strong>"
+        trustedCopyrightHtml="Copyright <em>2026</em>"
+      />
+    )
+
+    expect(view).toContain("<strong>Released</strong>")
+    expect(view).toContain("Copyright <em>2026</em>")
+  })
+})

--- a/packages/ardo/src/ui/Footer.tsx
+++ b/packages/ardo/src/ui/Footer.tsx
@@ -11,10 +11,14 @@ import { ArdoOwlMark } from "./OwlMark"
 // =============================================================================
 
 export type ArdoFooterProps = {
-  /** Footer message (supports HTML string) */
-  message?: string
-  /** Copyright text (supports HTML string) */
-  copyright?: string
+  /** Footer message rendered as React content. Strings are escaped. */
+  message?: ReactNode
+  /** Trusted footer message HTML. Use only for markup you fully control. */
+  trustedMessageHtml?: string
+  /** Copyright text rendered as React content. Strings are escaped. */
+  copyright?: ReactNode
+  /** Trusted copyright HTML. Use only for markup you fully control. */
+  trustedCopyrightHtml?: string
   /** Custom content (overrides all automatic rendering) */
   children?: ReactNode
   /** Additional CSS classes */
@@ -64,6 +68,11 @@ function formatBuildTime(iso: string): string {
  *   message="Released under the MIT License."
  *   copyright="Copyright 2026 Sebastian Software GmbH"
  * />
+ * ```
+ *
+ * @example Trusted HTML opt-in
+ * ```tsx
+ * <Footer trustedMessageHtml={'Released under the <a href="/license">MIT License</a>.'} />
  * ```
  *
  * @example Custom content
@@ -148,12 +157,46 @@ function FooterPrimaryLine({
   )
 }
 
+function hasFooterContent(value: ReactNode): boolean {
+  return value != null && value !== false && value !== ""
+}
+
+function FooterTextLine({
+  children,
+  className,
+  trustedHtml,
+}: {
+  children?: ReactNode
+  className: string
+  trustedHtml?: string
+}) {
+  const hasTrustedHtml = (trustedHtml ?? "") !== ""
+  if (hasTrustedHtml) {
+    return (
+      <p
+        className={className}
+        // The prop name marks this as caller-trusted HTML. Plain message/copyright props render escaped React content.
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{ __html: trustedHtml ?? "" }}
+      />
+    )
+  }
+
+  if (!hasFooterContent(children)) {
+    return null
+  }
+
+  return <p className={className}>{children}</p>
+}
+
 export function ArdoFooter({
   children,
   className,
   ardoLink = true,
   message,
+  trustedMessageHtml,
   copyright,
+  trustedCopyrightHtml,
   project,
   sponsor,
   buildTime,
@@ -180,15 +223,12 @@ export function ArdoFooter({
           ardoLink={ardoLink}
           config={config}
         />
-        {(message ?? "") !== "" && (
-          <p className={styles.footerMessage} dangerouslySetInnerHTML={{ __html: message ?? "" }} />
-        )}
-        {(copyright ?? "") !== "" && (
-          <p
-            className={styles.footerCopyright}
-            dangerouslySetInnerHTML={{ __html: copyright ?? "" }}
-          />
-        )}
+        <FooterTextLine className={styles.footerMessage} trustedHtml={trustedMessageHtml}>
+          {message}
+        </FooterTextLine>
+        <FooterTextLine className={styles.footerCopyright} trustedHtml={trustedCopyrightHtml}>
+          {copyright}
+        </FooterTextLine>
         {(resolvedBuildTime ?? "") !== "" && (
           <p className={styles.footerBuildTime}>
             Built on {formatBuildTime(resolvedBuildTime ?? "")}

--- a/packages/ardo/src/ui/components/CodeBlock.tsx
+++ b/packages/ardo/src/ui/components/CodeBlock.tsx
@@ -76,6 +76,7 @@ function CodeBlockContent({
   lineNumbers: boolean
   children?: React.ReactNode
 }) {
+  // The Ardo build plugin injects Shiki-generated HTML here. Runtime code samples and custom children render through React instead.
   if (hasHtml) return <div dangerouslySetInnerHTML={{ __html: html ?? "" }} />
   if (hasCustomChildren) return <>{children}</>
   return (


### PR DESCRIPTION
## Summary
- render Footer message/copyright as escaped React content by default
- add explicit trustedMessageHtml/trustedCopyrightHtml opt-in props for controlled markup
- add SSR coverage for escaped strings and trusted HTML, plus docs guidance

Closes #180.

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm exec vitest run packages/ardo/src/ui/Footer.test.tsx
- pnpm lint (0 errors, baseline warnings)
- pnpm build
- pnpm docs:build
- pre-push hook: pnpm -r typecheck + eslint packages/*/src (0 errors, baseline warnings)