### PR TITLE
feat: add neutral theme hue

### DIFF
--- a/docs/app/routes/guide/custom-theme.mdx
+++ b/docs/app/routes/guide/custom-theme.mdx
@@ -17,7 +17,9 @@ Start simple. Go deeper when you need to.
 
 ## Brand Color
 
-The fastest way to customize Ardo's look. Every color in the theme derives from a single OKLCH hue value. Change the hue and all backgrounds, text, borders, and brand colors update together — keeping the carefully tuned lightness and contrast relationships intact.
+The fastest way to customize Ardo's look. The default theme uses OKLCH hue tokens for brand, accent,
+and neutral chrome colors, so you can change the brand while keeping backgrounds, borders, header,
+sidebar, and text on a separate neutral base.
 
 Create a `.css.ts` file:
 
@@ -26,6 +28,18 @@ Create a `.css.ts` file:
 import { applyBrandTheme } from "ardo/theme"
 
 applyBrandTheme(240) // deep blue
+```
+
+Use the object form when your brand hue should not tint neutral chrome:
+
+```ts
+// styles/brand.css.ts
+import { applyBrandTheme } from "ardo/theme"
+
+applyBrandTheme({
+  primary: 130, // green brand
+  neutral: 260, // neutral slate chrome
+})
 ```
 
 Import it in your `root.tsx` after Ardo's styles:
@@ -49,7 +63,7 @@ The default hue is `356` (a muted berry tone). Some starting points:
 | `45`  | Orange          |
 | `130` | Green           |
 
-For full control over individual tokens, use `createTheme()` instead — it returns the complete `{ light, dark }` token sets for a given hue, which you can modify before passing to `createGlobalTheme`.
+For full control over individual tokens, use `createTheme()` instead — it returns the complete `{ light, dark }` token sets for a given hue set, which you can modify before passing to `createGlobalTheme`.
 
 ## CSS Variables
 
@@ -60,6 +74,10 @@ Create a custom CSS file:
 ```css
 /* styles/custom.css */
 :root {
+  --ardo-hue-brand: 260;
+  --ardo-hue-accent: 134;
+  --ardo-hue-neutral: 260;
+
   --ardo-color-brand: oklch(0.6 0.2 260);
   --ardo-color-brandLight: oklch(0.7 0.15 260);
   --ardo-color-brandDark: oklch(0.5 0.25 260);
@@ -79,6 +97,11 @@ Here's the full set of variables you can override. You don't need to set all of 
 
 ```css
 :root {
+  /* Hue knobs */
+  --ardo-hue-brand: 260;
+  --ardo-hue-accent: 134;
+  --ardo-hue-neutral: 260;
+
   /* Brand colors */
   --ardo-color-brand: oklch(0.62 0.19 260);
   --ardo-color-brandLight: oklch(0.7 0.14 260);
@@ -107,6 +130,15 @@ Here's the full set of variables you can override. You don't need to set all of 
   /* Border radius */
   --ardo-radius-base: 8px;
   --ardo-radius-sm: 4px;
+}
+```
+
+Most color tokens reference the hue variables, so retinting the neutral chrome usually only needs one
+declaration:
+
+```css
+:root {
+  --ardo-hue-neutral: 260;
 }
 ```
 
@@ -144,6 +176,7 @@ globalStyle(".ardo-content a", {
 The `vars` object provides tokens for:
 
 - **`vars.color`** — Brand colors, backgrounds, text, borders, shadows, and semantic colors (tip, warning, danger, info, note)
+- **`vars.hue`** — Brand, accent, and neutral hue custom properties used by the default color ramp
 - **`vars.layout`** — Sidebar width, TOC width, content max width, header height
 - **`vars.transition`** — Fast, base, and slow transition durations
 - **`vars.font`** — Font family and monospace family

--- a/docs/app/routes/guide/status-roadmap.mdx
+++ b/docs/app/routes/guide/status-roadmap.mdx
@@ -22,6 +22,7 @@ These capabilities are available in the current package line.
 | TypeDoc API reference   | Shipped | Built into the `ardo()` plugin for TypeScript library APIs.                                                            |
 | Social metadata         | Shipped | Generated canonical, Open Graph, and Twitter metadata for Markdown routes.                                             |
 | SEO build outputs       | Shipped | Sitemap, robots output, link checking, and static redirects are supported.                                             |
+| Theme hue overrides     | Shipped | Brand, accent, and neutral hue custom properties can retint the default color ramp from CSS.                           |
 | Core content components | Shipped | `Badge`, `Card`, `CardGroup`, `Tabs`, `Accordion`, `AccordionGroup`, callouts, steps, code blocks, hero, and features. |
 | Storybook playground    | Shipped | Default UI components have a local and static Storybook workflow.                                                      |
 
@@ -29,11 +30,11 @@ These capabilities are available in the current package line.
 
 These areas work, but the API or maintenance story may still evolve.
 
-| Area                  | Status       | Notes                                                                                                                                                                 |
-| --------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| TypeDoc customization | Experimental | Useful today, but richer category, grouping, and rendering controls may still change.                                                                                 |
-| Theme token overrides | Experimental | CSS variables and Vanilla Extract tokens are public, but easier neutral/chrome retinting is tracked in [#171](https://github.com/sebastian-software/ardo/issues/171). |
-| LLM text artifacts    | Experimental | The Ardo docs publish `llms.txt` files, while reusable automatic generation is tracked in [#70](https://github.com/sebastian-software/ardo/issues/70).                |
+| Area                  | Status       | Notes                                                                                                                                                  |
+| --------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| TypeDoc customization | Experimental | Useful today, but richer category, grouping, and rendering controls may still change.                                                                  |
+| Theme token overrides | Experimental | CSS variables and Vanilla Extract tokens are public, but the broader theming API and build-time customization story may still change.                  |
+| LLM text artifacts    | Experimental | The Ardo docs publish `llms.txt` files, while reusable automatic generation is tracked in [#70](https://github.com/sebastian-software/ardo/issues/70). |
 
 ## Planned
 

--- a/packages/ardo/src/ui/theme/contract.css.ts
+++ b/packages/ardo/src/ui/theme/contract.css.ts
@@ -4,6 +4,11 @@ const prefix = (value: string) => `ardo-${value}`
 
 export const vars = createGlobalThemeContract(
   {
+    hue: {
+      brand: null,
+      accent: null,
+      neutral: null,
+    },
     color: {
       brand: null,
       brandLight: null,

--- a/packages/ardo/src/ui/theme/tokens.test.ts
+++ b/packages/ardo/src/ui/theme/tokens.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { createTheme } from "./tokens"
+
+describe("createTheme", () => {
+  it("keeps the number API compatible while exposing CSS hue tokens", () => {
+    const theme = createTheme(130)
+
+    expect(theme.light.hue).toStrictEqual({
+      brand: "130",
+      accent: "4",
+      neutral: "130",
+    })
+    expect(theme.dark.hue).toStrictEqual(theme.light.hue)
+    expect(theme.light.color.brand).toBe("oklch(0.5 0.1 var(--ardo-hue-brand))")
+    expect(theme.light.color.bg).toBe("oklch(0.992 0.0015 var(--ardo-hue-neutral))")
+    expect(theme.dark.color.sidebarBg).toBe("oklch(0.13 0.008 var(--ardo-hue-neutral))")
+  })
+
+  it("supports a neutral hue independent from brand and accent hues", () => {
+    const theme = createTheme({ primary: 130, secondary: 45, neutral: 260 })
+
+    expect(theme.light.hue).toStrictEqual({
+      brand: "130",
+      accent: "45",
+      neutral: "260",
+    })
+    expect(theme.light.color.accent).toBe("oklch(0.5 0.075 var(--ardo-hue-accent))")
+    expect(theme.light.color.border).toBe("oklch(0.88 0.005 var(--ardo-hue-neutral))")
+    expect(theme.dark.color.text).toBe("oklch(0.94 0.004 var(--ardo-hue-neutral))")
+  })
+})

--- a/packages/ardo/src/ui/theme/tokens.ts
+++ b/packages/ardo/src/ui/theme/tokens.ts
@@ -7,9 +7,15 @@ import { createGlobalTheme } from "@vanilla-extract/css"
 
 import { vars } from "./contract.css"
 
+type HueValue = number | string
+
 // eslint-disable-next-line max-params -- mirrors CSS oklch() syntax
-const oklch = (l: number, c: number, h: number, alpha?: number) =>
+const oklch = (l: number, c: number, h: HueValue, alpha?: number) =>
   alpha !== undefined ? `oklch(${l} ${c} ${h} / ${alpha})` : `oklch(${l} ${c} ${h})`
+
+function hueOffset(hue: HueValue, offset: number): HueValue {
+  return typeof hue === "number" ? hue + offset : `calc(${hue} + ${offset})`
+}
 
 const fontFamily =
   'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif'
@@ -66,36 +72,32 @@ const shared = {
   },
 }
 
-function createLightColors(primary: number, secondary: number) {
-  // Neutrals carry the *primary* hue at very low chroma — the whole page
-  // reads as faintly warm, never blue or pink. Code surfaces (further down)
-  // explicitly use the secondary hue so they stay visibly cool against this
-  // warm base.
-  const neutralHue = primary
+function createLightColors() {
+  const primary = vars.hue.brand
+  const secondary = vars.hue.accent
+  const neutral = vars.hue.neutral
   return {
     brand: oklch(0.5, 0.1, primary),
     brandLight: oklch(0.62, 0.09, primary),
     brandDark: oklch(0.39, 0.11, primary),
     brandSubtle: oklch(0.955, 0.025, primary),
-    brandGradient: `linear-gradient(135deg, ${oklch(0.5, 0.1, primary)} 0%, ${oklch(0.6, 0.075, primary + 16)} 100%)`,
+    brandGradient: `linear-gradient(135deg, ${oklch(0.5, 0.1, primary)} 0%, ${oklch(0.6, 0.075, hueOffset(primary, 16))} 100%)`,
     accent: oklch(0.5, 0.075, secondary),
     accentLight: oklch(0.62, 0.07, secondary),
     accentDark: oklch(0.38, 0.085, secondary),
     accentSubtle: oklch(0.963, 0.012, secondary),
-    bg: oklch(0.992, 0.0015, neutralHue),
-    bgSoft: oklch(0.975, 0.003, neutralHue),
-    bgMute: oklch(0.955, 0.004, neutralHue),
-    bgAlt: oklch(0.935, 0.005, neutralHue),
-    text: oklch(0.17, 0.008, neutralHue),
-    textLight: oklch(0.4, 0.007, neutralHue),
-    textLighter: oklch(0.56, 0.005, neutralHue),
-    border: oklch(0.88, 0.005, neutralHue),
-    borderLight: oklch(0.925, 0.003, neutralHue),
-    divider: oklch(0.89, 0.004, neutralHue),
-    sidebarBg: oklch(0.965, 0.004, neutralHue),
-    sidebarBorder: oklch(0.885, 0.005, neutralHue),
-    // Code blocks live on the secondary (cool) hue — a visible step away
-    // from the warm neutrals so the two surfaces never read as the same.
+    bg: oklch(0.992, 0.0015, neutral),
+    bgSoft: oklch(0.975, 0.003, neutral),
+    bgMute: oklch(0.955, 0.004, neutral),
+    bgAlt: oklch(0.935, 0.005, neutral),
+    text: oklch(0.17, 0.008, neutral),
+    textLight: oklch(0.4, 0.007, neutral),
+    textLighter: oklch(0.56, 0.005, neutral),
+    border: oklch(0.88, 0.005, neutral),
+    borderLight: oklch(0.925, 0.003, neutral),
+    divider: oklch(0.89, 0.004, neutral),
+    sidebarBg: oklch(0.965, 0.004, neutral),
+    sidebarBorder: oklch(0.885, 0.005, neutral),
     codeBg: oklch(0.965, 0.012, secondary),
     codeBorder: oklch(0.88, 0.016, secondary),
     codeShadow: "0 1px 2px oklch(0 0 0 / 0.025)",
@@ -138,32 +140,32 @@ function createLightColors(primary: number, secondary: number) {
   }
 }
 
-function createDarkColors(primary: number, secondary: number) {
-  // See note in createLightColors — neutrals follow the primary hue.
-  const neutralHue = primary
+function createDarkColors() {
+  const primary = vars.hue.brand
+  const secondary = vars.hue.accent
+  const neutral = vars.hue.neutral
   return {
     brand: oklch(0.74, 0.115, primary),
     brandLight: oklch(0.84, 0.1, primary),
     brandDark: oklch(0.62, 0.125, primary),
     brandSubtle: oklch(0.275, 0.06, primary),
-    brandGradient: `linear-gradient(135deg, ${oklch(0.74, 0.115, primary)} 0%, ${oklch(0.81, 0.08, primary + 16)} 100%)`,
+    brandGradient: `linear-gradient(135deg, ${oklch(0.74, 0.115, primary)} 0%, ${oklch(0.81, 0.08, hueOffset(primary, 16))} 100%)`,
     accent: oklch(0.74, 0.08, secondary),
     accentLight: oklch(0.84, 0.07, secondary),
     accentDark: oklch(0.6, 0.09, secondary),
     accentSubtle: oklch(0.26, 0.03, secondary),
-    bg: oklch(0.155, 0.008, neutralHue),
-    bgSoft: oklch(0.195, 0.009, neutralHue),
-    bgMute: oklch(0.255, 0.01, neutralHue),
-    bgAlt: oklch(0.33, 0.01, neutralHue),
-    text: oklch(0.94, 0.004, neutralHue),
-    textLight: oklch(0.72, 0.007, neutralHue),
-    textLighter: oklch(0.55, 0.007, neutralHue),
-    border: oklch(0.285, 0.011, neutralHue),
-    borderLight: oklch(0.35, 0.01, neutralHue),
-    divider: oklch(0.29, 0.01, neutralHue),
-    sidebarBg: oklch(0.13, 0.008, neutralHue),
-    sidebarBorder: oklch(0.265, 0.011, neutralHue),
-    // Code blocks live on the secondary (cool) hue — same split as light.
+    bg: oklch(0.155, 0.008, neutral),
+    bgSoft: oklch(0.195, 0.009, neutral),
+    bgMute: oklch(0.255, 0.01, neutral),
+    bgAlt: oklch(0.33, 0.01, neutral),
+    text: oklch(0.94, 0.004, neutral),
+    textLight: oklch(0.72, 0.007, neutral),
+    textLighter: oklch(0.55, 0.007, neutral),
+    border: oklch(0.285, 0.011, neutral),
+    borderLight: oklch(0.35, 0.01, neutral),
+    divider: oklch(0.29, 0.01, neutral),
+    sidebarBg: oklch(0.13, 0.008, neutral),
+    sidebarBorder: oklch(0.265, 0.011, neutral),
     codeBg: oklch(0.21, 0.016, secondary),
     codeBorder: oklch(0.33, 0.024, secondary),
     codeShadow: "0 10px 26px oklch(0 0 0 / 0.18)",
@@ -218,8 +220,12 @@ function defaultSecondary(primary: number): number {
 }
 
 export type ArdoBrandHues = {
+  /** Main brand hue used by primary accents and calls to action. */
   primary: number
+  /** Accent hue used by secondary accents and code surfaces. Defaults from the primary hue. */
   secondary?: number
+  /** Neutral chrome hue used by backgrounds, borders, text, header, and sidebar. Defaults to primary. */
+  neutral?: number
 }
 
 export function createTheme(primaryOrHues: ArdoBrandHues | number, secondaryArg?: number) {
@@ -227,9 +233,26 @@ export function createTheme(primaryOrHues: ArdoBrandHues | number, secondaryArg?
   const explicitSecondary =
     typeof primaryOrHues === "number" ? secondaryArg : primaryOrHues.secondary
   const secondary = explicitSecondary ?? defaultSecondary(primary)
+  const neutral = typeof primaryOrHues === "number" ? primary : (primaryOrHues.neutral ?? primary)
   return {
-    light: { color: createLightColors(primary, secondary), ...shared },
-    dark: { color: createDarkColors(primary, secondary), ...shared },
+    light: {
+      hue: {
+        brand: String(primary),
+        accent: String(secondary),
+        neutral: String(neutral),
+      },
+      color: createLightColors(),
+      ...shared,
+    },
+    dark: {
+      hue: {
+        brand: String(primary),
+        accent: String(secondary),
+        neutral: String(neutral),
+      },
+      color: createDarkColors(),
+      ...shared,
+    },
   }
 }
 


### PR DESCRIPTION
## Summary
- add brand, accent, and neutral hue CSS custom properties to the theme contract
- let createTheme/applyBrandTheme accept an optional neutral hue while keeping the existing number API compatible
- make default color tokens reference the hue variables so neutral chrome can be retinted with a single CSS declaration
- document the CSS and object-form theme paths and update the feature status page

Closes #171.

## Validation
- pnpm exec vitest run packages/ardo/src/ui/theme/tokens.test.ts
- pnpm typecheck
- pnpm lint (0 errors, existing warnings only)
- pnpm format:check
- pnpm build
- pnpm docs:build
- pre-push hook: pnpm -r typecheck + eslint packages/*/src (0 errors, existing warnings only)