### PR TITLE
style: polish default home sections

### DIFF
--- a/packages/ardo/src/ui/components/Features.css.ts
+++ b/packages/ardo/src/ui/components/Features.css.ts
@@ -5,6 +5,8 @@ import { vars } from "../theme/contract.css"
 
 const brandBorder = `color-mix(in oklch, ${vars.color.brand} 38%, ${vars.color.border})`
 const brandRing = `color-mix(in oklch, ${vars.color.brand} 12%, transparent)`
+const brandPanel = `color-mix(in oklch, ${vars.color.brand} 5%, ${vars.color.bg})`
+const brandRail = `color-mix(in oklch, ${vars.color.brand} 42%, ${vars.color.border})`
 
 export const features = style({
   padding: "80px 24px",
@@ -50,27 +52,50 @@ export const featuresSubtitle = style({
 
 export const featuresContainer = style({
   display: "grid",
-  gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
-  gap: "20px",
+  gridTemplateColumns: "repeat(6, minmax(0, 1fr))",
+  gap: "18px",
   maxWidth: "1100px",
   margin: "0 auto",
+  "@media": {
+    "(max-width: 900px)": {
+      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    },
+    "(max-width: 640px)": {
+      gridTemplateColumns: "1fr",
+    },
+  },
 })
 
 export const feature = style({
+  position: "relative",
+  gridColumn: "span 2",
+  minHeight: "100%",
   padding: vars.space.lg,
-  background: vars.color.bg,
+  background: `linear-gradient(180deg, ${vars.color.bg} 0%, ${brandPanel} 100%)`,
   borderRadius: vars.radius.lg,
   border: `1px solid ${vars.color.border}`,
   boxShadow: vars.color.shadowSm,
   transition: `all ${vars.transition.base}`,
   animation: `${fadeInUp} 0.5s ease both`,
   selectors: {
+    "&::before": {
+      content: '""',
+      position: "absolute",
+      inset: "18px auto 18px 0",
+      width: "3px",
+      borderRadius: "999px",
+      background: brandRail,
+      opacity: 0.7,
+    },
     "&:hover": {
       borderColor: brandBorder,
       boxShadow: `${vars.color.shadowMd}, 0 0 0 1px ${brandRing}`,
     },
   },
   "@media": {
+    "(max-width: 900px)": {
+      gridColumn: "span 1",
+    },
     "(hover: hover)": {
       selectors: {
         "&:hover": {
@@ -89,6 +114,32 @@ export const feature = style({
   },
 })
 
+globalStyle(
+  `${featuresContainer} ${feature}:nth-child(1), ${featuresContainer} ${feature}:nth-child(2)`,
+  {
+    gridColumn: "span 3",
+  }
+)
+
+globalStyle(`${featuresContainer} ${feature}:nth-child(5n + 4)`, {
+  background: vars.color.bg,
+})
+
+globalStyle(`${featuresContainer} ${feature}:nth-child(5n)`, {
+  background: `linear-gradient(180deg, ${brandPanel} 0%, ${vars.color.bg} 100%)`,
+})
+
+globalStyle(
+  `${featuresContainer} ${feature}:nth-child(1), ${featuresContainer} ${feature}:nth-child(2)`,
+  {
+    "@media": {
+      "(max-width: 900px)": {
+        gridColumn: "span 1",
+      },
+    },
+  }
+)
+
 // Stagger animation delays
 for (let i = 1; i <= 6; i++) {
   globalStyle(`${featuresContainer} ${feature}:nth-child(${i})`, {
@@ -105,7 +156,7 @@ export const featureIcon = style({
   marginBottom: "16px",
   background: vars.color.brandSubtle,
   border: `1px solid color-mix(in oklch, ${vars.color.brand} 16%, ${vars.color.border})`,
-  borderRadius: "50%",
+  borderRadius: vars.radius.base,
   color: vars.color.brand,
   transition: `all ${vars.transition.base}`,
 })

--- a/packages/ardo/src/ui/components/Hero.css.ts
+++ b/packages/ardo/src/ui/components/Hero.css.ts
@@ -5,8 +5,9 @@ import { vars } from "../theme/contract.css"
 
 const brandHalo = `color-mix(in oklch, ${vars.color.brand} 26%, transparent)`
 const brandHaloStrong = `color-mix(in oklch, ${vars.color.brand} 36%, transparent)`
-const brandTint = `color-mix(in oklch, ${vars.color.brand} 10%, transparent)`
-const brandTintSoft = `color-mix(in oklch, ${vars.color.brand} 6%, transparent)`
+const brandPanel = `color-mix(in oklch, ${vars.color.brand} 7%, ${vars.color.bgSoft})`
+const brandRule = `color-mix(in oklch, ${vars.color.brand} 18%, ${vars.color.border})`
+const brandRuleStrong = `color-mix(in oklch, ${vars.color.brand} 32%, ${vars.color.border})`
 
 export const hero = style({
   padding: "100px 24px 80px",
@@ -21,11 +22,19 @@ export const hero = style({
       left: 0,
       right: 0,
       bottom: 0,
-      background: `radial-gradient(ellipse 60% 50% at 30% 0%, ${brandTintSoft} 0%, transparent 60%), radial-gradient(ellipse 80% 50% at 70% -10%, ${brandTint} 0%, transparent 70%), linear-gradient(180deg, ${vars.color.bg} 0%, ${vars.color.bgSoft} 100%)`,
+      background: `linear-gradient(180deg, ${vars.color.bg} 0%, ${brandPanel} 100%)`,
+      pointerEvents: "none",
+    },
+    "&::after": {
+      content: '""',
+      position: "absolute",
+      inset: "28px clamp(20px, 6vw, 88px) auto",
+      height: "1px",
+      background: `linear-gradient(90deg, transparent, ${brandRuleStrong}, transparent)`,
       pointerEvents: "none",
     },
     ".dark &::before": {
-      background: `radial-gradient(ellipse 60% 50% at 30% 0%, color-mix(in oklch, ${vars.color.brand} 12%, transparent) 0%, transparent 60%), radial-gradient(ellipse 80% 50% at 70% -10%, color-mix(in oklch, ${vars.color.brand} 18%, transparent) 0%, transparent 70%), linear-gradient(180deg, ${vars.color.bg} 0%, ${vars.color.bgSoft} 100%)`,
+      background: `linear-gradient(180deg, ${vars.color.bg} 0%, color-mix(in oklch, ${vars.color.brand} 10%, ${vars.color.bgSoft}) 100%)`,
     },
   },
   "@media": {
@@ -71,15 +80,30 @@ export const heroVersion = style({
 })
 
 export const heroName = style({
+  position: "relative",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "0 0.08em 0.08em",
   fontSize: "64px",
-  fontWeight: 800,
-  background: vars.color.brandGradient,
-  WebkitBackgroundClip: "text",
-  WebkitTextFillColor: "transparent",
-  backgroundClip: "text",
-  letterSpacing: "-0.03em",
-  lineHeight: 1.1,
+  fontWeight: 820,
+  color: vars.color.brand,
+  letterSpacing: "-0.035em",
+  lineHeight: 1.05,
   textWrap: "balance",
+  selectors: {
+    "&::after": {
+      content: '""',
+      position: "absolute",
+      left: "0.12em",
+      right: "0.12em",
+      bottom: 0,
+      height: "0.12em",
+      borderRadius: "999px",
+      background: brandRule,
+      zIndex: -1,
+    },
+  },
   "@media": {
     "(max-width: 768px)": {
       fontSize: "40px",
@@ -89,10 +113,10 @@ export const heroName = style({
 
 export const heroText = style({
   fontSize: "48px",
-  fontWeight: 700,
-  marginTop: "8px",
-  letterSpacing: "-0.02em",
-  lineHeight: 1.15,
+  fontWeight: 720,
+  marginTop: "12px",
+  letterSpacing: "-0.025em",
+  lineHeight: 1.12,
   textWrap: "balance",
   "@media": {
     "(max-width: 768px)": {


### PR DESCRIPTION
## Summary

- simplify the default hero background from decorative radial gradients to a calmer brand-tinted panel
- replace gradient hero text with solid brand text plus a subtle underline accent
- make the default feature grid less template-like with asymmetric desktop spans, soft card variation, and a vertical accent rail

Closes #181.

## Validation

- `pnpm exec prettier --write packages/ardo/src/ui/components/Hero.css.ts packages/ardo/src/ui/components/Features.css.ts`
- `pnpm --filter ardo typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm --filter ardo build`
- `pnpm docs:build`
