### PR TITLE
docs: document shipped P1 docs surfaces

### DIFF
--- a/docs/app/root.tsx
+++ b/docs/app/root.tsx
@@ -1,9 +1,19 @@
-import { ArdoErrorBoundary, ArdoRootLayout, ArdoRoot, ArdoFooter, ArdoSocialLink } from "ardo/ui"
+import {
+  ArdoErrorBoundary,
+  ArdoRootLayout,
+  ArdoRoot,
+  ArdoFooter,
+  ArdoSocialLink,
+  registerIcons,
+} from "ardo/ui"
+import { Code2, Rocket, Zap } from "lucide-react"
 import config from "virtual:ardo/config"
 import sidebars from "virtual:ardo/sidebars"
 import logo from "./assets/logo.svg"
 import type { MetaFunction } from "react-router"
 import "ardo/ui/styles.css"
+
+registerIcons({ Code2, Rocket, Zap })
 
 export const meta: MetaFunction = () => [
   { title: "Ardo" },

--- a/docs/app/routes/guide/configuration.mdx
+++ b/docs/app/routes/guide/configuration.mdx
@@ -165,6 +165,98 @@ ardo({
 
 Set `seo.llms: false` if you want to manage these files yourself from `public/`.
 
+### seo.sitemap
+
+- **Type:** `boolean | { changefreq?: "always" | "hourly" | "daily" | "weekly" | "monthly" | "yearly" | "never"; priority?: number }`
+- **Default:** `true`
+
+Generates `/sitemap.xml` from Markdown and MDX routes. Ardo combines `siteUrl`, `base`, and each
+route path so subpath deployments still produce absolute URLs.
+
+```ts
+ardo({
+  title: "My Docs",
+  siteUrl: "https://example.com",
+  base: "/docs/",
+  seo: {
+    sitemap: {
+      changefreq: "weekly",
+      priority: 0.7,
+    },
+  },
+})
+```
+
+Set `seo.sitemap: false` to skip sitemap generation. Set `sitemap: false` in page frontmatter to
+exclude a single Markdown route.
+
+### seo.robots
+
+- **Type:** `boolean | { allow?: string[]; disallow?: string[] }`
+- **Default:** `true`
+
+Generates `/robots.txt`. By default Ardo allows all crawlers and points them at the generated
+sitemap when `siteUrl` is configured.
+
+```ts
+ardo({
+  title: "My Docs",
+  siteUrl: "https://example.com",
+  seo: {
+    robots: {
+      allow: ["/"],
+      disallow: ["/drafts/"],
+    },
+  },
+})
+```
+
+Set `seo.robots: false` if you want to provide your own `robots.txt` from `public/`.
+
+### linkCheck
+
+- **Type:** `{ enabled?: boolean; checkAnchors?: boolean; exclude?: string[]; level?: "warn" | "error" }`
+- **Default:** `{ enabled: true, checkAnchors: true, level: "warn" }`
+
+Checks internal links in Markdown and MDX content at build time. Ardo reports missing routes and,
+unless disabled, missing heading anchors.
+
+```ts
+ardo({
+  title: "My Docs",
+  linkCheck: {
+    level: "error",
+    exclude: ["/storybook/*", "/generated/*"],
+  },
+})
+```
+
+Use `checkAnchors: false` when another tool rewrites heading ids after Ardo has read the route
+manifest. Use `enabled: false` only when another link checker owns the build gate.
+
+### redirects
+
+- **Type:** `Array<{ from: string; to: string }>`
+- **Default:** `[]`
+
+Generates static redirect assets for configured legacy paths:
+
+- `_redirects` for Netlify-style hosts
+- `vercel.json` redirect entries
+- HTML redirect files for static hosts that only serve files
+
+```ts
+ardo({
+  title: "My Docs",
+  redirects: [
+    { from: "/old-guide", to: "/guide/getting-started" },
+    { from: "/v1/config", to: "/guide/configuration" },
+  ],
+})
+```
+
+Use frontmatter `redirectFrom` when a redirect belongs to one page instead of the whole site.
+
 ### srcDir
 
 - **Type:** `string`

--- a/docs/app/routes/guide/configuration.mdx
+++ b/docs/app/routes/guide/configuration.mdx
@@ -579,7 +579,9 @@ Options controlling the generated markdown output.
 
 ## UI Configuration
 
-Navigation, sidebar, footer, editLink, lastUpdated, and search are configured via JSX props in your `root.tsx` using `<ArdoRoot>`. See [Custom Theme](/guide/custom-theme) for details.
+Navigation, sidebar, footer, editLink, lastUpdated, and search are configured via JSX props in your
+`root.tsx` using `<ArdoRoot>`. See [Site UI Configuration](/guide/site-ui) for the `ArdoRoot`,
+header, footer, and context-sidebar reference.
 
 ---
 

--- a/docs/app/routes/guide/frontmatter.mdx
+++ b/docs/app/routes/guide/frontmatter.mdx
@@ -175,6 +175,57 @@ lastUpdated: false
 ---
 ```
 
+## Build Output Options
+
+### sitemap
+
+- Type: `boolean`
+- Default: `true`
+
+Exclude a Markdown route from the generated sitemap without hiding it from navigation.
+
+```yaml
+---
+title: Internal Migration Notes
+sitemap: false
+---
+```
+
+### llms
+
+- Type: `boolean`
+- Default: `true`
+
+Exclude a Markdown route from `/llms.txt` and `/llms-full.txt`. This is useful for pages that are
+valid docs for humans but noisy in a single-file model context, such as generated changelogs or
+large fixture references.
+
+```yaml
+---
+title: Fixture Catalog
+llms: false
+---
+```
+
+### redirectFrom
+
+- Type: `string | string[]`
+
+Generate static redirects from old paths to this page. Use a string for one legacy path or an array
+for several old locations.
+
+```yaml
+---
+title: Configuration
+redirectFrom:
+  - /config
+  - /guide/options
+---
+```
+
+Ardo combines page-level redirects with the global `redirects` array from `ardo()` config and emits
+host-friendly redirect assets during production builds.
+
 ### prev / next
 
 - Type: `string | { text: string; link: string } | false`

--- a/docs/app/routes/guide/markdown.mdx
+++ b/docs/app/routes/guide/markdown.mdx
@@ -237,6 +237,185 @@ Use `Accordion` and `AccordionGroup` for collapsible FAQ items, optional explana
 
 Each accordion also supports an optional `icon` and can be used standalone without a group.
 
+## Cards
+
+Use `Card` and `CardGroup` for compact navigation, feature summaries, and reference lists. They are
+auto-registered in MDX files, so no import is needed.
+
+<CardGroup cols={3}>
+  <Card title="Configuration" href="/guide/configuration">
+    Build-time options for routes, Markdown, TypeDoc, SEO outputs, and deployment helpers.
+  </Card>
+  <Card title="Site UI" href="/guide/site-ui">
+    React-side props for the header, sidebar, footer, edit links, and context navigation.
+  </Card>
+  <Card title="Frontmatter" href="/guide/frontmatter">
+    Page-level metadata, navigation controls, and build-output overrides.
+  </Card>
+</CardGroup>
+
+```mdx
+<CardGroup cols={3}>
+  <Card title="Configuration" href="/guide/configuration">
+    Build-time options for routes, Markdown, TypeDoc, SEO outputs, and deployment helpers.
+  </Card>
+  <Card title="Site UI" href="/guide/site-ui">
+    React-side props for the header, sidebar, footer, edit links, and context navigation.
+  </Card>
+  <Card title="Frontmatter" href="/guide/frontmatter">
+    Page-level metadata, navigation controls, and build-output overrides.
+  </Card>
+</CardGroup>
+```
+
+| Component   | Prop        | Type                  | Purpose                                                              |
+| ----------- | ----------- | --------------------- | -------------------------------------------------------------------- |
+| `CardGroup` | `cols`      | `1 \| 2 \| 3 \| 4`    | Preferred number of columns on wide screens. Defaults to `2`.        |
+| `CardGroup` | `children`  | `ReactNode`           | Cards to render in the responsive grid.                              |
+| `Card`      | `title`     | `string`              | Required card heading.                                               |
+| `Card`      | `href`      | `string`              | Optional internal or external destination. Makes the card clickable. |
+| `Card`      | `icon`      | `string \| ReactNode` | Registered icon name or custom React node.                           |
+| `Card`      | `children`  | `ReactNode`           | Body content.                                                        |
+| `Card`      | `className` | `string`              | Additional CSS class.                                                |
+
+## Tabs
+
+Use `Tabs` when readers need to switch between equivalent variants, such as package managers,
+framework integrations, or deployment providers.
+
+<Tabs defaultValue="pnpm">
+  <TabList>
+    <Tab value="pnpm">pnpm</Tab>
+    <Tab value="npm">npm</Tab>
+    <Tab value="yarn">Yarn</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel value="pnpm">
+
+```bash
+pnpm create ardo my-docs
+```
+
+    </TabPanel>
+    <TabPanel value="npm">
+
+```bash
+npm create ardo@latest my-docs
+```
+
+    </TabPanel>
+    <TabPanel value="yarn">
+
+```bash
+yarn create ardo my-docs
+```
+
+    </TabPanel>
+
+  </TabPanels>
+</Tabs>
+
+````mdx
+<Tabs defaultValue="pnpm">
+  <TabList>
+    <Tab value="pnpm">pnpm</Tab>
+    <Tab value="npm">npm</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel value="pnpm">
+
+```bash
+pnpm create ardo my-docs
+```
+
+    </TabPanel>
+    <TabPanel value="npm">
+
+```bash
+npm create ardo@latest my-docs
+```
+
+    </TabPanel>
+
+  </TabPanels>
+</Tabs>
+````
+
+| Component  | Prop           | Type        | Purpose                                                                |
+| ---------- | -------------- | ----------- | ---------------------------------------------------------------------- |
+| `Tabs`     | `defaultValue` | `string`    | Initial active tab value. Defaults to the first tab.                   |
+| `Tabs`     | `children`     | `ReactNode` | A `TabList` and matching `TabPanels`.                                  |
+| `Tab`      | `value`        | `string`    | Stable value that matches a `TabPanel`. Optional when order is stable. |
+| `Tab`      | `children`     | `ReactNode` | Tab label.                                                             |
+| `TabPanel` | `value`        | `string`    | Matching value for the tab content. Optional when order matches tabs.  |
+| `TabPanel` | `children`     | `ReactNode` | Panel content.                                                         |
+
+## Steps
+
+Use `Steps` for ordered setup or migration instructions. The component expects an ordered list as
+its child and styles it as a step-by-step sequence.
+
+<Steps>
+  <ol>
+    <li>Create a route file in `app/routes/guide`.</li>
+    <li>Add frontmatter with a `title`, `description`, and `order`.</li>
+    <li>Run the docs build to validate links and generated output.</li>
+  </ol>
+</Steps>
+
+```mdx
+<Steps>
+  <ol>
+    <li>Create a route file in `app/routes/guide`.</li>
+    <li>Add frontmatter with a `title`, `description`, and `order`.</li>
+    <li>Run the docs build to validate links and generated output.</li>
+  </ol>
+</Steps>
+```
+
+| Component | Prop       | Type        | Purpose                                     |
+| --------- | ---------- | ----------- | ------------------------------------------- |
+| `Steps`   | `children` | `ReactNode` | Usually an `<ol>` with one `<li>` per step. |
+
+## Icons
+
+Use `Icon` when MDX content needs a registered SVG icon by name. Icons are opt-in: register only the
+icons your site uses, usually in `root.tsx` or another file that runs before MDX pages render.
+
+```tsx
+import { registerIcons } from "ardo/ui"
+import { Code2, Rocket, Zap } from "lucide-react"
+
+registerIcons({ Code2, Rocket, Zap })
+```
+
+Once registered, the same names are available in MDX:
+
+<CardGroup cols={3}>
+  <Card title="Fast authoring" icon="Zap">
+    Use Markdown until a page needs richer React components.
+  </Card>
+  <Card title="API-ready" icon="Code2">
+    Combine written guides with generated API reference pages.
+  </Card>
+  <Card title="Launchable" icon="Rocket">
+    Ship sitemap, robots, redirects, and LLM text artifacts from one build.
+  </Card>
+</CardGroup>
+
+```mdx
+<Icon name="Zap" size={20} />
+<Card title="Fast authoring" icon="Zap">
+  Use Markdown until a page needs richer React components.
+</Card>
+```
+
+| Component | Prop      | Type                           | Purpose                                 |
+| --------- | --------- | ------------------------------ | --------------------------------------- |
+| `Icon`    | `name`    | `string`                       | Registered icon name.                   |
+| `Icon`    | `size`    | `number`                       | Optional rendered icon size.            |
+| `Icon`    | SVG props | `SVGAttributes<SVGSVGElement>` | Passed to the registered SVG component. |
+
 ## Code Groups
 
 Display multiple code variants in tabs:

--- a/docs/app/routes/guide/site-ui.mdx
+++ b/docs/app/routes/guide/site-ui.mdx
@@ -1,0 +1,198 @@
+---
+title: Site UI Configuration
+description: Configure ArdoRoot, header, footer, edit links, last-updated metadata, and context sidebars from root.tsx.
+order: 6
+---
+
+# Site UI Configuration
+
+Build-time options belong in `ardo()` config. Site chrome belongs in React. Configure the header,
+sidebar, footer, edit links, last-updated metadata, and multi-section sidebars in your app's
+`root.tsx` with `<ArdoRoot>`.
+
+## Minimal Root
+
+Every Ardo app needs the generated config and sidebar data. Import them from virtual modules and
+pass them to `ArdoRoot`.
+
+```tsx
+import { ArdoRoot, ArdoRootLayout } from "ardo/ui"
+import config from "virtual:ardo/config"
+import sidebar from "virtual:ardo/sidebar"
+import "ardo/ui/styles.css"
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  return <ArdoRootLayout>{children}</ArdoRootLayout>
+}
+
+export default function Root() {
+  return <ArdoRoot config={config} sidebar={sidebar} />
+}
+```
+
+`ArdoRootLayout` owns the document-level theme bootstrap and global shell setup. `ArdoRoot` owns the
+React Router outlet, Ardo providers, default header, sidebar, and footer.
+
+## ArdoRoot Props
+
+| Prop             | Type                                                                               | Purpose                                                                        |
+| ---------------- | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `config`         | `ArdoConfig`                                                                       | Generated site config from `virtual:ardo/config`.                              |
+| `sidebar`        | `SidebarItem[] \| Record<string, SidebarItem[]>`                                   | Generated sidebar data from `virtual:ardo/sidebar` or `virtual:ardo/sidebars`. |
+| `contexts`       | `ArdoContextItem[]`                                                                | Optional rail items for switching between multiple sidebar contexts.           |
+| `header`         | `ReactNode`                                                                        | Replace the entire default header.                                             |
+| `sidebarContent` | `ReactNode`                                                                        | Replace the generated sidebar content.                                         |
+| `footer`         | `ReactNode`                                                                        | Replace the default footer element.                                            |
+| `headerProps`    | `ArdoHeaderProps`                                                                  | Configure the default header. Ignored when `header` is provided.               |
+| `sidebarProps`   | `ArdoSidebarProps`                                                                 | Configure the default sidebar. Ignored when `sidebarContent` is provided.      |
+| `footerProps`    | `ArdoFooterProps`                                                                  | Configure the default footer. Ignored when `footer` is provided.               |
+| `editLink`       | `{ pattern: string; text?: string }`                                               | Site-wide edit-link pattern for Markdown pages.                                |
+| `lastUpdated`    | `{ enabled?: boolean; text?: string; formatOptions?: Intl.DateTimeFormatOptions }` | Site-wide last-updated display settings.                                       |
+| `tocLabel`       | `string`                                                                           | Label for the generated table-of-contents panel.                               |
+| `className`      | `string`                                                                           | Replace the default layout class.                                              |
+| `children`       | `ReactNode`                                                                        | Replace the default React Router `<Outlet />` content.                         |
+
+## Header
+
+Use `headerProps` when you want the default responsive header but need to configure the logo,
+navigation, search, theme toggle, or action area.
+
+```tsx
+import { ArdoNav, ArdoNavLink, ArdoSocialLink } from "ardo/ui"
+import logo from "./assets/logo.svg"
+
+export default function Root() {
+  return (
+    <ArdoRoot
+      config={config}
+      sidebar={sidebar}
+      headerProps={{
+        logo,
+        title: "My Docs",
+        searchPlaceholder: "Search documentation...",
+        nav: (
+          <ArdoNav>
+            <ArdoNavLink to="/guide/getting-started">Guide</ArdoNavLink>
+            <ArdoNavLink to="/api-reference">API</ArdoNavLink>
+          </ArdoNav>
+        ),
+        actions: <ArdoSocialLink href="https://github.com/example/project" icon="github" />,
+      }}
+    />
+  )
+}
+```
+
+| Header prop         | Purpose                                                                  |
+| ------------------- | ------------------------------------------------------------------------ |
+| `logo`              | String URL or `{ light, dark }` logo variants.                           |
+| `title`             | Header title. Defaults to `config.title`.                                |
+| `nav`               | Desktop navigation content, usually `ArdoNav` and `ArdoNavLink`.         |
+| `actions`           | Right-side actions such as `ArdoSocialLink` or custom buttons.           |
+| `search`            | Set to `false` to hide search. Defaults to `true`.                       |
+| `searchPlaceholder` | Placeholder for the search input.                                        |
+| `themeToggle`       | Set to `false` to hide the theme toggle. Defaults to `true`.             |
+| `mobileMenuContent` | Additional content for the mobile menu. `ArdoRoot` supplies the sidebar. |
+| `className`         | Replace the default header class.                                        |
+
+Pass `header` instead of `headerProps` when your design needs a fully custom header element.
+
+## Footer
+
+For light customization, pass `footerProps`. For the common "default footer with sponsor and
+copyright" case, pass an explicit `footer` element.
+
+```tsx
+import { ArdoFooter } from "ardo/ui"
+
+export default function Root() {
+  return (
+    <ArdoRoot
+      config={config}
+      sidebar={sidebar}
+      footer={
+        <ArdoFooter
+          sponsor={{ text: "Example Co", link: "https://example.com" }}
+          message="Released under the MIT License."
+          copyright="Copyright 2026 Example Co"
+        />
+      }
+    />
+  )
+}
+```
+
+| Footer prop            | Purpose                                                                 |
+| ---------------------- | ----------------------------------------------------------------------- |
+| `message`              | React content rendered as footer message text.                          |
+| `copyright`            | React content rendered as copyright text.                               |
+| `trustedMessageHtml`   | Trusted HTML for the message line. Do not pass user-provided content.   |
+| `trustedCopyrightHtml` | Trusted HTML for the copyright line. Do not pass user-provided content. |
+| `project`              | Project metadata override for the linked package/version line.          |
+| `sponsor`              | Sponsor link rendered as "Sponsored by ...".                            |
+| `buildTime`            | Build timestamp override. Defaults to generated config metadata.        |
+| `buildHash`            | Git hash override. Defaults to generated config metadata.               |
+| `ardoLink`             | Set to `false` to hide the "Built with Ardo" link.                      |
+| `children`             | Full custom footer content. Skips automatic footer rendering.           |
+| `className`            | Replace the default footer class.                                       |
+
+## Edit Links and Last Updated
+
+`editLink` and `lastUpdated` are site-wide content settings. Ardo applies them to Markdown and MDX
+document pages, and page frontmatter can opt out with `editLink: false` or `lastUpdated: false`.
+
+```tsx
+<ArdoRoot
+  config={config}
+  sidebar={sidebar}
+  editLink={{
+    pattern: "https://github.com/example/project/edit/main/docs/app/routes/:path",
+    text: "Edit this page on GitHub",
+  }}
+  lastUpdated={{
+    enabled: true,
+    text: "Last updated",
+    formatOptions: { dateStyle: "medium" },
+  }}
+  tocLabel="On this page"
+/>
+```
+
+The `:path` placeholder receives the route file path relative to the generated Markdown route root.
+
+## Context Sidebars
+
+Use `virtual:ardo/sidebars` and `contexts` when your docs have distinct areas, such as guide pages
+and generated API reference pages. The sidebar rail becomes a context switcher, and `ArdoRoot`
+selects the active sidebar map entry by context id.
+
+```tsx
+import { ArdoRoot } from "ardo/ui"
+import config from "virtual:ardo/config"
+import sidebars from "virtual:ardo/sidebars"
+
+export default function Root() {
+  return (
+    <ArdoRoot
+      config={config}
+      sidebar={sidebars}
+      contexts={[
+        { id: "guide", label: "Guide", href: "/guide/getting-started" },
+        { id: "api-reference", label: "API", href: "/api-reference" },
+      ]}
+    />
+  )
+}
+```
+
+Each context item has:
+
+| Field   | Purpose                                                                                     |
+| ------- | ------------------------------------------------------------------------------------------- |
+| `id`    | Sidebar map key. Conventionally the top-level route folder, such as `guide` or `api`.       |
+| `label` | Text shown in the sidebar rail tooltip.                                                     |
+| `href`  | Landing link for the context. Also used to infer the default active route prefix.           |
+| `match` | Optional string prefix or `RegExp` when `href` is not enough to match the context's routes. |
+
+Use `virtual:ardo/sidebar` for a single global sidebar. Use `virtual:ardo/sidebars` only when you
+want context-aware navigation.


### PR DESCRIPTION
## Summary
- documents the shipped SEO/build-output surface: `seo.sitemap`, `seo.robots`, `linkCheck`, `redirects`, plus `sitemap`, `llms`, and `redirectFrom` frontmatter
- adds a dedicated Site UI Configuration guide for `ArdoRoot`, header/footer props, edit links, last-updated metadata, and context sidebars
- documents auto-registered MDX content components with live examples and prop tables for Cards, Tabs, Steps, and Icons

Closes #239
Closes #240
Closes #241
Refs #246

## Validation
- `pnpm format:check`
- `pnpm build`
- `pnpm typecheck`
- `pnpm docs:build` (passes; emits existing generated API/sample-link warnings)
- pre-push hook: `pnpm -r typecheck`, `eslint packages/*/src` (passes with existing warnings)
