### PR TITLE
Fix P2 config and build core issues

### DIFF
--- a/packages/ardo/src/config/index.test.ts
+++ b/packages/ardo/src/config/index.test.ts
@@ -116,4 +116,26 @@ describe("resolveConfig", () => {
       attrs: { name: "author", content: "Test Author" },
     })
   })
+
+  it("rejects base paths without leading and trailing slashes", () => {
+    expect(() => resolveConfig({ title: "Test", base: "docs" }, "/project")).toThrow(
+      "base must start and end"
+    )
+
+    expect(() => resolveConfig({ title: "Test", base: "/docs" }, "/project")).toThrow(
+      "base must start and end"
+    )
+  })
+
+  it("rejects invalid site URLs", () => {
+    expect(() => resolveConfig({ title: "Test", siteUrl: "not a url" }, "/project")).toThrow(
+      "siteUrl must be an absolute URL"
+    )
+  })
+
+  it("rejects sitemap priorities outside the sitemap range", () => {
+    expect(() =>
+      resolveConfig({ title: "Test", seo: { sitemap: { priority: 2 } } }, "/project")
+    ).toThrow("seo.sitemap.priority must be between 0 and 1")
+  })
 })

--- a/packages/ardo/src/config/index.ts
+++ b/packages/ardo/src/config/index.ts
@@ -1,4 +1,6 @@
+import fs from "node:fs"
 import path from "node:path"
+import { URL } from "node:url"
 
 import type {
   ArdoConfig,
@@ -24,6 +26,10 @@ import type {
   TOCItem,
   TypeDocConfig,
 } from "./types"
+
+type ConfigModule = {
+  default?: unknown
+}
 
 export type {
   ArdoConfig,
@@ -67,6 +73,8 @@ export const defaultMarkdownConfig: MarkdownConfig = {
 }
 
 export function resolveConfig(config: ArdoConfig, root: string): ResolvedConfig {
+  validateConfig(config)
+
   const srcDir = config.srcDir ?? "content"
   const contentDir = path.resolve(root, srcDir)
 
@@ -98,21 +106,43 @@ export function resolveConfig(config: ArdoConfig, root: string): ResolvedConfig 
 
 export async function loadConfig(root: string): Promise<ResolvedConfig> {
   const configPath = path.resolve(root, "press.config.ts")
-
-  try {
-    const configModule: unknown = await import(configPath)
-    const config =
-      typeof configModule === "object" && configModule !== null && "default" in configModule
-        ? configModule.default
-        : undefined
-
-    if (isArdoConfig(config)) {
-      return resolveConfig(config, root)
-    }
-  } catch {
-    // Fall through to default config
+  if (!fs.existsSync(configPath)) {
+    return resolveDefaultConfig(root)
   }
 
+  const configModule = await importConfigModule(configPath)
+  if (configModule == null) {
+    return resolveDefaultConfig(root)
+  }
+
+  const config = configModule.default
+
+  if (isArdoConfig(config)) {
+    return resolveConfig(config, root)
+  }
+
+  console.warn(`[ardo] Config at ${configPath} does not export a valid Ardo config.`)
+  console.warn("[ardo] Falling back to defaults.")
+  return resolveDefaultConfig(root)
+}
+
+async function importConfigModule(configPath: string): Promise<ConfigModule | undefined> {
+  try {
+    const configModule: unknown = await import(configPath)
+    if (typeof configModule === "object" && configModule !== null && "default" in configModule) {
+      return configModule
+    }
+    return {}
+  } catch (error) {
+    console.warn(`[ardo] Failed to load config at ${configPath}. Falling back to defaults.`)
+    if (error instanceof Error) {
+      console.warn(`[ardo] ${error.message}`)
+    }
+    return undefined
+  }
+}
+
+function resolveDefaultConfig(root: string): ResolvedConfig {
   return resolveConfig(
     {
       title: "Ardo",
@@ -120,6 +150,44 @@ export async function loadConfig(root: string): Promise<ResolvedConfig> {
     },
     root
   )
+}
+
+function validateConfig(config: ArdoConfig): void {
+  const errors: string[] = []
+
+  if (config.base !== undefined && !isValidBasePath(config.base)) {
+    errors.push('base must start and end with "/" (for example "/docs/").')
+  }
+
+  if (config.siteUrl !== undefined && config.siteUrl !== "" && !isValidUrl(config.siteUrl)) {
+    errors.push("siteUrl must be an absolute URL.")
+  }
+
+  const sitemapPriority =
+    typeof config.seo?.sitemap === "object" ? config.seo.sitemap.priority : undefined
+  if (
+    sitemapPriority !== undefined &&
+    (!Number.isFinite(sitemapPriority) || sitemapPriority < 0 || sitemapPriority > 1)
+  ) {
+    errors.push("seo.sitemap.priority must be between 0 and 1.")
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`[ardo] Invalid config:\n${errors.map((error) => `- ${error}`).join("\n")}`)
+  }
+}
+
+function isValidBasePath(value: string): boolean {
+  return value === "/" || (value.startsWith("/") && value.endsWith("/"))
+}
+
+function isValidUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 function isArdoConfig(value: unknown): value is ArdoConfig {

--- a/packages/ardo/src/markdown/heading-slug.test.ts
+++ b/packages/ardo/src/markdown/heading-slug.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { createHeadingSlugger, slugifyHeadingText } from "./heading-slug"
+
+describe("slugifyHeadingText", () => {
+  it("preserves unicode letters and strips markdown punctuation", () => {
+    expect(slugifyHeadingText("Über `uns` & Einführung")).toBe("über-uns-einführung")
+  })
+
+  it("normalizes whitespace and trims dashes", () => {
+    expect(slugifyHeadingText("  Hello   world!  ")).toBe("hello-world")
+  })
+})
+
+describe("createHeadingSlugger", () => {
+  it("deduplicates repeated heading ids", () => {
+    const slugger = createHeadingSlugger()
+
+    expect(slugger.slug("Example")).toBe("example")
+    expect(slugger.slug("Example")).toBe("example-1")
+    expect(slugger.slug("Example")).toBe("example-2")
+  })
+
+  it("uses deterministic fallback ids for empty headings", () => {
+    const slugger = createHeadingSlugger()
+
+    expect(slugger.slug("!!!")).toBe("heading-0")
+    expect(slugger.slug("???")).toBe("heading-1")
+  })
+})

--- a/packages/ardo/src/markdown/heading-slug.ts
+++ b/packages/ardo/src/markdown/heading-slug.ts
@@ -1,0 +1,52 @@
+export type HeadingSlugger = {
+  slug: (text: string) => string
+}
+
+export function createHeadingSlugger(fallbackPrefix = "heading"): HeadingSlugger {
+  const seen = new Map<string, number>()
+  let fallbackIndex = 0
+
+  return {
+    slug(text: string) {
+      const baseSlug = slugifyHeadingText(text)
+      const base = baseSlug === "" ? `${fallbackPrefix}-${fallbackIndex++}` : baseSlug
+      const count = seen.get(base) ?? 0
+      seen.set(base, count + 1)
+      return count === 0 ? base : `${base}-${count}`
+    },
+  }
+}
+
+export function slugifyHeadingText(text: string): string {
+  let slug = stripHtmlTags(text)
+    .toLowerCase()
+    .trim()
+    .replaceAll(/[`*_~[\]()]/gu, "")
+    .replaceAll(/[^\p{Letter}\p{Number}\s-]/gu, "")
+    .replaceAll(/[\s_]+/gu, "-")
+
+  while (slug.includes("--")) {
+    slug = slug.replaceAll("--", "-")
+  }
+
+  return slug.replaceAll(/^-|-$/gu, "")
+}
+
+function stripHtmlTags(value: string): string {
+  let result = ""
+  let isInsideTag = false
+  for (const character of value) {
+    if (character === "<") {
+      isInsideTag = true
+      continue
+    }
+
+    if (character === ">") {
+      isInsideTag = false
+      continue
+    }
+
+    if (!isInsideTag) result += character
+  }
+  return result
+}

--- a/packages/ardo/src/markdown/pipeline.ts
+++ b/packages/ardo/src/markdown/pipeline.ts
@@ -39,7 +39,11 @@ export async function transformMarkdown(
     .use(remarkParse)
     .use(remarkFrontmatter, ["yaml"])
     .use(remarkGfm)
-    .use(remarkExtractToc, { tocExtraction, levels: config.toc?.level ?? [2, 3] })
+    .use(remarkExtractToc, {
+      anchor: config.anchor,
+      tocExtraction,
+      levels: config.toc?.level ?? [2, 3],
+    })
     .use(remarkRehype, { allowDangerousHtml: true })
     .use(rehypeShikiFromHighlighter, { highlighter, config })
     .use(rehypeLinks, { basePath })

--- a/packages/ardo/src/markdown/remark-mdx-toc.ts
+++ b/packages/ardo/src/markdown/remark-mdx-toc.ts
@@ -12,7 +12,11 @@ import { visit } from "unist-util-visit"
 
 import type { TOCItem } from "../config/types"
 
+import { createHeadingSlugger } from "./heading-slug"
+
 type RemarkMdxTocOptions = {
+  /** Add heading ids for anchor links (default: true) */
+  anchor?: boolean
   /** Export name (default: "toc") */
   name?: string
   /** Heading levels to include (default: [2, 3]) */
@@ -20,26 +24,26 @@ type RemarkMdxTocOptions = {
 }
 
 export function remarkMdxToc(options: RemarkMdxTocOptions = {}) {
-  const { name = "toc", levels = [2, 3] } = options
+  const { anchor = true, name = "toc", levels = [2, 3] } = options
   const [minLevel, maxLevel] = levels
 
   return function (tree: Root, file: Parameters<typeof define>[1]) {
     const items: TOCItem[] = []
-    let headingIndex = 0
+    const slugger = createHeadingSlugger()
 
     visit(tree, "heading", (node: Heading) => {
       if (node.depth < minLevel || node.depth > maxLevel) return
 
       const text = getHeadingText(node)
-      const slug = slugify(text)
-      const id = slug === "" ? `heading-${String(headingIndex)}` : slug
-      headingIndex++
+      const id = slugger.slug(text)
 
       items.push({ id, text, level: node.depth })
 
-      // Add id to the heading node for anchor links
-      const hProperties = ensureHProperties(node)
-      hProperties.id = id
+      if (anchor) {
+        // Add id to the heading node for anchor links
+        const hProperties = ensureHProperties(node)
+        hProperties.id = id
+      }
     })
 
     // Use the same approach as remark-mdx-frontmatter: valueToEstree + define
@@ -62,20 +66,6 @@ function getHeadingText(node: Heading): string {
 
   for (const child of node.children) extract(child)
   return parts.join("")
-}
-
-function slugify(text: string): string {
-  let slug = text
-    .toLowerCase()
-    .trim()
-    .replaceAll(/[^\s\w-]/g, "")
-    .replaceAll(/[\s_]/g, "-")
-
-  while (slug.includes("--")) {
-    slug = slug.replaceAll("--", "-")
-  }
-
-  return slug.replaceAll(/^-|-$/g, "")
 }
 
 type HeadingDataWithHProperties = {

--- a/packages/ardo/src/markdown/toc.ts
+++ b/packages/ardo/src/markdown/toc.ts
@@ -4,22 +4,25 @@ import { visit } from "unist-util-visit"
 
 import type { TOCItem } from "../config/types"
 
+import { createHeadingSlugger } from "./heading-slug"
+
 export type TocExtraction = {
   toc: TOCItem[]
 }
 
 type TocOptions = {
+  anchor?: boolean
   tocExtraction: TocExtraction
   levels: [number, number]
 }
 
 export function remarkExtractToc(options: TocOptions) {
-  const { tocExtraction, levels } = options
+  const { anchor = true, tocExtraction, levels } = options
   const [minLevel, maxLevel] = levels
 
   return function (tree: Root) {
     const headings: Array<{ text: string; level: number; id: string }> = []
-    let headingIndex = 0
+    const slugger = createHeadingSlugger()
 
     visit(tree, "heading", (node: Heading) => {
       if (node.depth < minLevel || node.depth > maxLevel) {
@@ -27,9 +30,7 @@ export function remarkExtractToc(options: TocOptions) {
       }
 
       const text = getHeadingText(node)
-      const slug = slugify(text)
-      const id = slug === "" ? `heading-${headingIndex}` : slug
-      headingIndex++
+      const id = slugger.slug(text)
 
       headings.push({
         text,
@@ -37,9 +38,11 @@ export function remarkExtractToc(options: TocOptions) {
         id,
       })
 
-      // Add id to the heading node for anchor links
-      const hProperties = ensureHProperties(node)
-      hProperties.id = id
+      if (anchor) {
+        // Add id to the heading node for anchor links
+        const hProperties = ensureHProperties(node)
+        hProperties.id = id
+      }
     })
 
     tocExtraction.toc = buildTocTree(headings)
@@ -67,28 +70,6 @@ function getHeadingText(node: Heading): string {
     extractText(child)
   })
   return textParts.join("")
-}
-
-function slugify(text: string): string {
-  let slug = text
-    .toLowerCase()
-    .trim()
-    .replaceAll(/[^\s\w-]/g, "")
-    .replaceAll(/[\s_]/g, "-")
-
-  while (slug.includes("--")) {
-    slug = slug.replaceAll("--", "-")
-  }
-
-  if (slug.startsWith("-")) {
-    slug = slug.slice(1)
-  }
-
-  if (slug.endsWith("-")) {
-    slug = slug.slice(0, -1)
-  }
-
-  return slug
 }
 
 function popStackUntilParent(stack: Array<{ item: TOCItem; level: number }>, level: number): void {

--- a/packages/ardo/src/ui/Nav.tsx
+++ b/packages/ardo/src/ui/Nav.tsx
@@ -1,5 +1,5 @@
 import { type ComponentProps, createContext, type ReactNode, use, useMemo, useState } from "react"
-import { NavLink as RouterNavLink } from "react-router"
+import { NavLink as RouterNavLink, useLocation } from "react-router"
 
 import * as styles from "./Nav.css"
 
@@ -72,14 +72,9 @@ export type ArdoNavLinkProps = {
  * <NavLink href="https://github.com/...">GitHub</NavLink>
  * ```
  */
-export function ArdoNavLink({
-  to,
-  href,
-  children,
-  className,
-  activeMatch: _activeMatch,
-}: ArdoNavLinkProps) {
+export function ArdoNavLink({ to, href, children, className, activeMatch }: ArdoNavLinkProps) {
   const navContext = useNavContext()
+  const { pathname } = useLocation()
   const baseClassName = className ?? styles.navLink
   const hasHref = (href ?? "") !== ""
   const hasTo = to !== undefined
@@ -110,7 +105,9 @@ export function ArdoNavLink({
       <RouterNavLink
         to={to}
         className={({ isActive }: { isActive: boolean }) =>
-          [baseClassName, isActive && "active"].filter(Boolean).join(" ")
+          [baseClassName, (isActive || matchesActiveMatch(pathname, activeMatch)) && "active"]
+            .filter(Boolean)
+            .join(" ")
         }
         onClick={handleClick}
       >
@@ -121,6 +118,18 @@ export function ArdoNavLink({
 
   // Text-only (no link)
   return <span className={baseClassName}>{children}</span>
+}
+
+function matchesActiveMatch(pathname: string, activeMatch: string | undefined): boolean {
+  if (activeMatch == null || activeMatch === "") {
+    return false
+  }
+
+  try {
+    return new RegExp(activeMatch, "u").test(pathname)
+  } catch {
+    return pathname.startsWith(activeMatch)
+  }
 }
 
 // =============================================================================

--- a/packages/ardo/src/vite/base.ts
+++ b/packages/ardo/src/vite/base.ts
@@ -1,0 +1,17 @@
+export function normalizeViteBaseForArdo(viteBase: string): string {
+  const trimmedBase = viteBase.trim()
+  if (trimmedBase === "" || trimmedBase === "./") {
+    return "/"
+  }
+
+  if (trimmedBase.startsWith("http://") || trimmedBase.startsWith("https://")) {
+    return normalizeBasePath(new URL(trimmedBase).pathname)
+  }
+
+  return normalizeBasePath(trimmedBase.startsWith("/") ? trimmedBase : `/${trimmedBase}`)
+}
+
+function normalizeBasePath(base: string): string {
+  const withLeadingSlash = base.startsWith("/") ? base : `/${base}`
+  return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`
+}

--- a/packages/ardo/src/vite/flatten-plugin.test.ts
+++ b/packages/ardo/src/vite/flatten-plugin.test.ts
@@ -1,0 +1,46 @@
+import type { Plugin } from "vite"
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { createFlattenPlugin } from "./flatten-plugin"
+
+type FlattenPluginHooks = {
+  closeBundle: () => Promise<void> | void
+  configResolved: (config: { base: string; build: { outDir: string }; root: string }) => void
+}
+
+describe("createFlattenPlugin", () => {
+  it("flattens from the resolved build output directory per plugin instance", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "ardo-flatten-"))
+    try {
+      const root = path.join(tmpDir, "project")
+      const buildDir = path.join(root, "custom-client")
+      await mkdir(path.join(buildDir, "docs"), { recursive: true })
+      await writeFile(path.join(buildDir, "docs", "index.html"), "nested", "utf8")
+
+      const plugin = createFlattenPlugin()
+      if (!hasFlattenPluginHooks(plugin)) {
+        throw new Error("Flatten plugin hooks not found")
+      }
+
+      plugin.configResolved({
+        base: "/docs/",
+        build: { outDir: "custom-client" },
+        root,
+      })
+
+      await plugin.closeBundle()
+
+      await expect(readFile(path.join(buildDir, "index.html"), "utf8")).resolves.toBe("nested")
+    } finally {
+      await rm(tmpDir, { force: true, recursive: true })
+    }
+  })
+})
+
+function hasFlattenPluginHooks(plugin: Plugin): plugin is FlattenPluginHooks & Plugin {
+  return typeof plugin.configResolved === "function" && typeof plugin.closeBundle === "function"
+}

--- a/packages/ardo/src/vite/flatten-plugin.ts
+++ b/packages/ardo/src/vite/flatten-plugin.ts
@@ -5,16 +5,17 @@ import path from "node:path"
 
 import { copyRecursive } from "./git-utils"
 
-let flattenExecuted = false
-
 export function createFlattenPlugin(): Plugin {
   let detectedBase: string | undefined
+  let buildDir = path.resolve(process.cwd(), "build", "client")
+  let flattenExecuted = false
 
   return {
     name: "ardo:flatten-github-pages",
     enforce: "post",
     configResolved(config) {
       detectedBase = config.base === "/" ? undefined : config.base
+      buildDir = path.resolve(config.root, config.build.outDir)
     },
     closeBundle() {
       if (flattenExecuted || detectedBase == null) {
@@ -26,13 +27,12 @@ export function createFlattenPlugin(): Plugin {
         return
       }
 
-      const buildDir = path.join(process.cwd(), "build", "client")
       const nestedDir = path.join(buildDir, baseName)
       if (!fs.existsSync(nestedDir)) {
         return
       }
 
-      console.log(`[ardo] Flattening build/client/${baseName}/ to build/client/ for GitHub Pages`)
+      console.log(`[ardo] Flattening ${path.relative(process.cwd(), nestedDir)} for GitHub Pages`)
       copyRecursive(nestedDir, buildDir)
       fs.rmSync(nestedDir, { recursive: true, force: true })
       console.log("[ardo] Build output flattened successfully.")

--- a/packages/ardo/src/vite/git-utils.test.ts
+++ b/packages/ardo/src/vite/git-utils.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+
+import { getGitHubPagesBase } from "./git-utils"
+
+describe("getGitHubPagesBase", () => {
+  it("uses repo subpaths for project pages", () => {
+    expect(getGitHubPagesBase("ardo")).toBe("/ardo/")
+  })
+
+  it("uses the root base for user and organization pages", () => {
+    expect(getGitHubPagesBase("sebastian-software.github.io")).toBe("/")
+  })
+})

--- a/packages/ardo/src/vite/git-utils.ts
+++ b/packages/ardo/src/vite/git-utils.ts
@@ -55,7 +55,11 @@ export function detectGitHubBasename(cwd?: string): string {
   }
 
   const repoName = detectGitHubRepoName(cwd ?? process.cwd())
-  return repoName != null ? `/${repoName}/` : "/"
+  return repoName != null ? getGitHubPagesBase(repoName) : "/"
+}
+
+export function getGitHubPagesBase(repoName: string): string {
+  return repoName.endsWith(".github.io") ? "/" : `/${repoName}/`
 }
 
 /**

--- a/packages/ardo/src/vite/mdx-plugin.ts
+++ b/packages/ardo/src/vite/mdx-plugin.ts
@@ -41,7 +41,10 @@ export function createMdxPlugin(markdownConfig: ArdoConfig["markdown"]): Plugin 
       remarkGfm,
       remarkCallouts,
       remarkCodeMeta,
-      [remarkMdxToc, { levels: markdownConfig?.toc?.level ?? [2, 3] }],
+      [
+        remarkMdxToc,
+        { anchor: markdownConfig?.anchor, levels: markdownConfig?.toc?.level ?? [2, 3] },
+      ],
     ],
     rehypePlugins: [[rehypeShiki, shikiOptions]],
     recmaPlugins: [recmaWrapExport],

--- a/packages/ardo/src/vite/plugin.test.ts
+++ b/packages/ardo/src/vite/plugin.test.ts
@@ -31,14 +31,17 @@ describe("ardoPlugin", () => {
     const plugin = getMainPlugin({
       githubPages: false,
       title: "Docs",
-      vite: { define: { __CUSTOM__: JSON.stringify(true) }, server: { port: 4455 } },
+      vite: {
+        define: { __BUILD_TIME__: JSON.stringify("custom"), __CUSTOM__: JSON.stringify(true) },
+        server: { port: 4455 },
+      },
     })
 
     const config = plugin.config({ root: "/project" }, { command: "build", mode: "production" })
 
     expect(config.server?.port).toBe(4455)
     expect(config.define).toMatchObject({
-      __BUILD_TIME__: expect.any(String),
+      __BUILD_TIME__: '"custom"',
       __CUSTOM__: "true",
     })
   })
@@ -63,5 +66,33 @@ describe("ardoPlugin", () => {
     const code = await plugin.load("\0virtual:ardo/config")
 
     expect(String(code)).toContain('"base":"/docs/"')
+  })
+
+  it("normalizes absolute Vite bases before exposing the virtual Ardo config", async () => {
+    const plugin = getMainPlugin({ githubPages: false, title: "Docs" })
+
+    plugin.configResolved({
+      base: "https://cdn.example.com/assets/docs/",
+      build: { ssr: false },
+      root: "/project",
+    })
+
+    const code = await plugin.load("\0virtual:ardo/config")
+
+    expect(String(code)).toContain('"base":"/assets/docs/"')
+  })
+
+  it("normalizes relative Vite bases before exposing the virtual Ardo config", async () => {
+    const plugin = getMainPlugin({ githubPages: false, title: "Docs" })
+
+    plugin.configResolved({
+      base: "./",
+      build: { ssr: false },
+      root: "/project",
+    })
+
+    const code = await plugin.load("\0virtual:ardo/config")
+
+    expect(String(code)).toContain('"base":"/"')
   })
 })

--- a/packages/ardo/src/vite/plugin.test.ts
+++ b/packages/ardo/src/vite/plugin.test.ts
@@ -1,0 +1,67 @@
+import type { Plugin, UserConfig } from "vite"
+
+import { describe, expect, it } from "vitest"
+
+import { ardoPlugin } from "./plugin"
+
+type ArdoPluginHooks = {
+  config: (config: UserConfig, env: { command: "build" | "serve"; mode: string }) => UserConfig
+  configResolved: (config: { base: string; build: { ssr: boolean }; root: string }) => void
+  load: (id: string) => Promise<string | undefined>
+}
+
+function getMainPlugin(options: Parameters<typeof ardoPlugin>[0]): ArdoPluginHooks {
+  const plugin = ardoPlugin(options).find((entry) => entry.name === "ardo")
+  if (plugin == null || !hasArdoPluginHooks(plugin)) {
+    throw new Error("Main Ardo plugin not found")
+  }
+  return plugin
+}
+
+function hasArdoPluginHooks(plugin: Plugin): plugin is ArdoPluginHooks & Plugin {
+  return (
+    typeof plugin.config === "function" &&
+    typeof plugin.configResolved === "function" &&
+    typeof plugin.load === "function"
+  )
+}
+
+describe("ardoPlugin", () => {
+  it("merges the public vite config option into the returned Vite config", () => {
+    const plugin = getMainPlugin({
+      githubPages: false,
+      title: "Docs",
+      vite: { define: { __CUSTOM__: JSON.stringify(true) }, server: { port: 4455 } },
+    })
+
+    const config = plugin.config({ root: "/project" }, { command: "build", mode: "production" })
+
+    expect(config.server?.port).toBe(4455)
+    expect(config.define).toMatchObject({
+      __BUILD_TIME__: expect.any(String),
+      __CUSTOM__: "true",
+    })
+  })
+
+  it("maps outDir to Vite build.outDir", () => {
+    const plugin = getMainPlugin({ githubPages: false, title: "Docs", outDir: "custom-build" })
+
+    const config = plugin.config({ root: "/project" }, { command: "build", mode: "production" })
+
+    expect(config.build?.outDir).toBe("custom-build")
+  })
+
+  it("uses resolved Vite base in the virtual Ardo config", async () => {
+    const plugin = getMainPlugin({ githubPages: false, title: "Docs" })
+
+    plugin.configResolved({
+      base: "/docs/",
+      build: { ssr: false },
+      root: "/project",
+    })
+
+    const code = await plugin.load("\0virtual:ardo/config")
+
+    expect(String(code)).toContain('"base":"/docs/"')
+  })
+})

--- a/packages/ardo/src/vite/plugin.ts
+++ b/packages/ardo/src/vite/plugin.ts
@@ -4,6 +4,7 @@ import { mergeConfig, type Plugin, type UserConfig, type ViteDevServer } from "v
 import type { ArdoConfig, ProjectMeta, ResolvedConfig } from "../config/types"
 
 import { resolveConfig } from "../config/index"
+import { normalizeViteBaseForArdo } from "./base"
 import {
   checkInternalLinks,
   createBuildOutputAssets,
@@ -250,7 +251,7 @@ function resolveArdoConfig(
     {
       ...configWithDefaults,
       ...pressConfig,
-      base: pressConfig.base ?? viteBase,
+      base: pressConfig.base ?? normalizeViteBaseForArdo(viteBase),
       project,
     },
     root
@@ -265,7 +266,7 @@ function mergeArdoViteConfig(
     return ardoConfig
   }
 
-  return mergeConfig(viteConfig as UserConfig, ardoConfig)
+  return mergeConfig(ardoConfig, viteConfig as UserConfig)
 }
 
 function resolveVirtualModuleId(id: string): string | undefined {

--- a/packages/ardo/src/vite/plugin.ts
+++ b/packages/ardo/src/vite/plugin.ts
@@ -1,6 +1,5 @@
-import type { Plugin, UserConfig, ViteDevServer } from "vite"
-
 import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin"
+import { mergeConfig, type Plugin, type UserConfig, type ViteDevServer } from "vite"
 
 import type { ArdoConfig, ProjectMeta, ResolvedConfig } from "../config/types"
 
@@ -12,7 +11,12 @@ import {
 } from "./build-outputs"
 import { ardoCodeBlockPlugin } from "./codeblock-plugin"
 import { createFlattenPlugin } from "./flatten-plugin"
-import { detectGitHash, detectGitHubBasename, detectGitHubRepoName } from "./git-utils"
+import {
+  detectGitHash,
+  detectGitHubBasename,
+  detectGitHubRepoName,
+  getGitHubPagesBase,
+} from "./git-utils"
 import { type ArdoIconOptions, createIconsPlugin } from "./icons"
 import { transformMarkdownMeta } from "./markdown-meta"
 import { createMdxPlugin, getReactRouterPlugins } from "./mdx-plugin"
@@ -138,13 +142,14 @@ function createMainPlugin(state: PluginState, options: MainPluginOptions): Plugi
         userConfig,
         command: env.command,
         githubPages: options.githubPages,
+        pressConfig: options.pressConfig,
         routesDirOption: options.routesDirOption,
       })
     },
     configResolved(config) {
       state.isSsrBuild = config.build.ssr !== false
       state.routesDir = resolveRoutesDir(config.root, options.routesDirOption)
-      state.resolvedConfig = resolveArdoConfig(config.root, state.routesDir, options.pressConfig)
+      state.resolvedConfig = resolveArdoConfig(config.root, options.pressConfig, config.base)
     },
     resolveId(id) {
       return resolveVirtualModuleId(id)
@@ -199,11 +204,12 @@ function createMainConfig(
   input: {
     command: string
     githubPages: boolean
+    pressConfig: PressConfigOptions
     routesDirOption: string | undefined
     userConfig: UserConfig
   }
 ): UserConfig {
-  const { command, githubPages, routesDirOption, userConfig } = input
+  const { command, githubPages, pressConfig, routesDirOption, userConfig } = input
   const root = userConfig.root ?? process.cwd()
   state.routesDir = resolveRoutesDir(root, routesDirOption)
 
@@ -216,18 +222,22 @@ function createMainConfig(
   if (githubPages && command === "build" && userConfig.base == null) {
     const repoName = detectGitHubRepoName(root)
     if (repoName != null) {
-      config.base = `/${repoName}/`
+      config.base = getGitHubPagesBase(repoName)
       console.log(`[ardo] GitHub Pages detected, using base: ${config.base}`)
     }
   }
 
-  return config
+  if (pressConfig.outDir != null) {
+    config.build = { ...config.build, outDir: pressConfig.outDir }
+  }
+
+  return mergeArdoViteConfig(pressConfig.vite, config)
 }
 
 function resolveArdoConfig(
   root: string,
-  routesDir: string,
-  pressConfig: PressConfigOptions
+  pressConfig: PressConfigOptions,
+  viteBase: string
 ): ResolvedConfig {
   const detectedProject = readProjectMeta(root)
   const project: ProjectMeta = { ...detectedProject, ...pressConfig.project }
@@ -240,11 +250,22 @@ function resolveArdoConfig(
     {
       ...configWithDefaults,
       ...pressConfig,
+      base: pressConfig.base ?? viteBase,
       project,
-      srcDir: routesDir,
     },
     root
   )
+}
+
+function mergeArdoViteConfig(
+  viteConfig: Record<string, unknown> | undefined,
+  ardoConfig: UserConfig
+): UserConfig {
+  if (viteConfig == null) {
+    return ardoConfig
+  }
+
+  return mergeConfig(viteConfig as UserConfig, ardoConfig)
 }
 
 function resolveVirtualModuleId(id: string): string | undefined {

--- a/packages/ardo/src/vite/route-manifest.test.ts
+++ b/packages/ardo/src/vite/route-manifest.test.ts
@@ -1,0 +1,25 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { scanRouteManifest } from "./route-manifest"
+
+describe("scanRouteManifest", () => {
+  it("extracts unicode and deduplicated heading anchors", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "ardo-routes-"))
+    try {
+      await writeFile(
+        path.join(tmpDir, "guide.mdx"),
+        ["# Guide", "## Über uns", "## Über uns", "## `API` & Usage"].join("\n"),
+        "utf8"
+      )
+
+      const [entry] = await scanRouteManifest(tmpDir)
+
+      expect(entry.anchors).toStrictEqual(["guide", "über-uns", "über-uns-1", "api-usage"])
+    } finally {
+      await rm(tmpDir, { force: true, recursive: true })
+    }
+  })
+})

--- a/packages/ardo/src/vite/route-manifest.ts
+++ b/packages/ardo/src/vite/route-manifest.ts
@@ -4,6 +4,8 @@ import matter from "gray-matter"
 import fs from "node:fs/promises"
 import path from "node:path"
 
+import { createHeadingSlugger } from "../markdown/heading-slug"
+
 export type RouteManifestEntry = {
   anchors: string[]
   content: string
@@ -123,12 +125,13 @@ function parseRedirectFrom(value: unknown): string[] | undefined {
 }
 
 function extractAnchors(content: string): string[] {
-  const anchors = new Set<string>()
+  const anchors: string[] = []
+  const slugger = createHeadingSlugger()
   for (const line of content.split("\n")) {
     const headingText = getMarkdownHeadingText(line)
-    if (headingText != null) anchors.add(slugifyHeading(headingText))
+    if (headingText != null) anchors.push(slugger.slug(headingText))
   }
-  return [...anchors]
+  return anchors
 }
 
 function getMarkdownHeadingText(line: string): null | string {
@@ -144,34 +147,6 @@ function getMarkdownHeadingText(line: string): null | string {
   }
 
   return trimmed.slice(level + 1)
-}
-
-function slugifyHeading(value: string) {
-  return stripHtmlTags(value)
-    .replaceAll(/[`*_~[\]()]/gu, "")
-    .trim()
-    .toLowerCase()
-    .replaceAll(/[^\d\p{Letter}\s-]/gu, "")
-    .replaceAll(/\s+/gu, "-")
-}
-
-function stripHtmlTags(value: string) {
-  let result = ""
-  let isInsideTag = false
-  for (const character of value) {
-    if (character === "<") {
-      isInsideTag = true
-      continue
-    }
-
-    if (character === ">") {
-      isInsideTag = false
-      continue
-    }
-
-    if (!isInsideTag) result += character
-  }
-  return result
 }
 
 function toRecord(value: unknown): Record<string, unknown> {

--- a/packages/ardo/src/vite/typedoc-plugin.ts
+++ b/packages/ardo/src/vite/typedoc-plugin.ts
@@ -67,6 +67,9 @@ export function createTypeDocPlugin(
     async buildStart() {
       await generateTypeDocOnce()
     },
+    buildEnd() {
+      typedocGenerated = false
+    },
   }
 }
 


### PR DESCRIPTION
## Description

Fixes the next Epic #246 P2 core batch:

- centralizes heading slug generation across rendered headings and route-manifest link checking, including Unicode and duplicate heading ids
- validates config values instead of silently accepting invalid `base`, `siteUrl`, or sitemap priority values
- keeps config-load fallback behavior for missing/broken config files while warning clearly
- honors public options that were previously inert: `vite`, `outDir`, `markdown.anchor`, resolved Vite `base`, and `ArdoNavLink.activeMatch`
- uses `/` for `*.github.io` GitHub Pages repositories instead of `/<repo>/`
- resets build plugin one-shot state per plugin/build instance and resolves flattening from the configured build output directory

Closes #209.
Closes #210.
Closes #211.
Closes #212.
Closes #213.
Refs #246.

## Motivation and Context

These issues share the same build/config surface. Keeping them together avoids several small PRs that would otherwise touch the same Vite plugin, markdown pipeline, and route-manifest behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm format` and `pnpm lint`
- [x] I have added tests that prove my fix/feature works (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] All existing tests pass (`pnpm test`)
- [x] TypeScript compiles without errors (`pnpm typecheck`)

## Screenshots (if applicable)

Not applicable.

## Additional Notes

Validation:

- `pnpm format:check`
- `pnpm lint` (passes with existing warnings)
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` (passed outside sandbox; sandbox run failed on React Router `listen EPERM ::1` and scaffold install timeout)
- `pnpm docs:build` (passed outside sandbox; reports pre-existing generated API/demo broken-link warnings)
