### PR TITLE
Fix UI accessibility regressions

### DIFF
--- a/packages/ardo/src/ui/Header.css.ts
+++ b/packages/ardo/src/ui/Header.css.ts
@@ -74,6 +74,23 @@ export const logo = style({
   height: "2rem",
 })
 
+export const logoLight = style({
+  selectors: {
+    ".dark &": {
+      display: "none",
+    },
+  },
+})
+
+export const logoDark = style({
+  display: "none",
+  selectors: {
+    ".dark &": {
+      display: "block",
+    },
+  },
+})
+
 export const siteTitle = style({
   fontSize: vars.fontSize.lg,
   fontWeight: 700,

--- a/packages/ardo/src/ui/Header.tsx
+++ b/packages/ardo/src/ui/Header.tsx
@@ -5,6 +5,7 @@ import { useArdoConfig } from "../runtime/hooks"
 import { ArdoHeaderSearch } from "./components/HeaderSearch"
 import { ArdoThemeToggle } from "./components/ThemeToggle"
 import * as styles from "./Header.css"
+import { type ArdoLogo, HeaderLogo } from "./HeaderLogo"
 import {
   GithubIcon,
   LinkedinIcon,
@@ -22,7 +23,7 @@ import * as navStyles from "./Nav.css"
 
 export type ArdoHeaderProps = {
   /** Logo image URL or light/dark variants */
-  logo?: { light: string; dark: string } | string
+  logo?: ArdoLogo
   /** Site title displayed next to logo */
   title?: string
   /** Navigation content (Nav component or custom) */
@@ -111,13 +112,7 @@ export function ArdoHeader({
               </button>
             )}
             <Link to="/" className={styles.logoLink}>
-              {hasLogo && (
-                <img
-                  src={typeof resolvedLogo === "string" ? resolvedLogo : resolvedLogo.light}
-                  alt={resolvedTitle}
-                  className={styles.logo}
-                />
-              )}
+              {hasLogo && <HeaderLogo logo={resolvedLogo} alt={resolvedTitle} />}
               {hasTitle && <span className={styles.siteTitle}>{resolvedTitle}</span>}
             </Link>
           </div>

--- a/packages/ardo/src/ui/HeaderLogo.test.tsx
+++ b/packages/ardo/src/ui/HeaderLogo.test.tsx
@@ -1,0 +1,16 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+
+import { HeaderLogo } from "./HeaderLogo"
+
+describe("HeaderLogo", () => {
+  it("renders both light and dark logo variants", () => {
+    const view = renderToStaticMarkup(
+      <HeaderLogo logo={{ light: "/logo-light.svg", dark: "/logo-dark.svg" }} alt="Docs" />
+    )
+
+    expect(view).toContain('src="/logo-light.svg"')
+    expect(view).toContain('src="/logo-dark.svg"')
+    expect(view.match(/alt="Docs"/g)).toHaveLength(2)
+  })
+})

--- a/packages/ardo/src/ui/HeaderLogo.tsx
+++ b/packages/ardo/src/ui/HeaderLogo.tsx
@@ -1,0 +1,16 @@
+import * as styles from "./Header.css"
+
+export type ArdoLogo = { light: string; dark: string } | string
+
+export function HeaderLogo({ alt, logo }: { alt: string; logo: ArdoLogo }) {
+  if (typeof logo === "string") {
+    return <img src={logo} alt={alt} className={styles.logo} />
+  }
+
+  return (
+    <>
+      <img src={logo.light} alt={alt} className={`${styles.logo} ${styles.logoLight}`} />
+      <img src={logo.dark} alt={alt} className={`${styles.logo} ${styles.logoDark}`} />
+    </>
+  )
+}

--- a/packages/ardo/src/ui/MobileSlidePanel.tsx
+++ b/packages/ardo/src/ui/MobileSlidePanel.tsx
@@ -3,17 +3,9 @@ import { Link } from "react-router"
 
 import { ArdoThemeToggle } from "./components/ThemeToggle"
 import * as styles from "./Header.css"
+import { type ArdoLogo, HeaderLogo } from "./HeaderLogo"
 import { XIcon } from "./icons"
-import { getTrappedFocusTarget } from "./mobile-drawer-a11y"
-
-const FOCUSABLE_SELECTOR = [
-  "a[href]",
-  "button:not([disabled])",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
-  '[tabindex]:not([tabindex="-1"])',
-].join(",")
+import { focusInitialElement, trapFocus } from "./mobile-drawer-a11y"
 
 export function MobileSlidePanel({
   logo,
@@ -24,7 +16,7 @@ export function MobileSlidePanel({
   children,
   onClose,
 }: {
-  logo?: { light: string; dark: string } | string
+  logo?: ArdoLogo
   title: string
   nav?: ReactNode
   themeToggle?: boolean
@@ -52,13 +44,7 @@ export function MobileSlidePanel({
       >
         <div className={styles.mobilePanelHeader}>
           <Link to="/" className={styles.logoLink} onClick={onClose}>
-            {logo != null && (
-              <img
-                src={typeof logo === "string" ? logo : logo.light}
-                alt={title}
-                className={styles.logo}
-              />
-            )}
+            {logo != null && <HeaderLogo logo={logo} alt={title} />}
           </Link>
           <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
             {themeToggle && <ArdoThemeToggle />}
@@ -103,7 +89,7 @@ function useMobilePanelFocus({
     }
     const triggerElement = triggerRef.current
 
-    focusInitialPanelElement(panel)
+    focusInitialElement(panel)
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -113,7 +99,7 @@ function useMobilePanelFocus({
       }
 
       if (event.key === "Tab") {
-        trapPanelFocus(event, panel)
+        trapFocus(event, panel)
       }
     }
 
@@ -123,36 +109,6 @@ function useMobilePanelFocus({
       triggerElement?.focus()
     }
   }, [onClose, panelRef, triggerRef])
-}
-
-function focusInitialPanelElement(panel: HTMLDivElement) {
-  const focusableElements = getFocusablePanelElements(panel)
-  const initialFocusTarget = focusableElements[0] ?? panel
-  initialFocusTarget.focus()
-}
-
-function trapPanelFocus(event: KeyboardEvent, panel: HTMLDivElement) {
-  const focusableElements = getFocusablePanelElements(panel)
-  const activeElement =
-    document.activeElement instanceof HTMLElement ? document.activeElement : null
-  const target = getTrappedFocusTarget({
-    activeElement,
-    focusableElements,
-    shiftKey: event.shiftKey,
-  })
-
-  if (target == null) {
-    return
-  }
-
-  event.preventDefault()
-  target.focus()
-}
-
-function getFocusablePanelElements(panel: HTMLDivElement) {
-  return [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
-    (element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true"
-  )
 }
 
 function handleLinkClick(onClose: () => void) {

--- a/packages/ardo/src/ui/Sidebar.css.ts
+++ b/packages/ardo/src/ui/Sidebar.css.ts
@@ -207,6 +207,19 @@ export const sidebarTextButton = style({
   lineHeight: "inherit",
   textAlign: "left",
   cursor: "pointer",
+  justifyContent: "space-between",
+})
+
+export const sidebarToggleChevron = style({
+  display: "flex",
+  alignItems: "center",
+  color: vars.color.textLighter,
+  transition: `all ${vars.transition.base}`,
+  selectors: {
+    "&.collapsed": {
+      transform: "rotate(-90deg)",
+    },
+  },
 })
 
 export const sidebarCollapse = style({

--- a/packages/ardo/src/ui/Sidebar.test.tsx
+++ b/packages/ardo/src/ui/Sidebar.test.tsx
@@ -1,0 +1,52 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { MemoryRouter } from "react-router"
+import { describe, expect, it } from "vitest"
+
+import type { SidebarItem } from "../config/types"
+
+import { ArdoProvider } from "../runtime/hooks"
+import { ArdoSidebar } from "./Sidebar"
+
+function renderSidebar(items: SidebarItem[]): string {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/"]}>
+      <ArdoProvider config={{ title: "Docs" }} sidebar={[]}>
+        <ArdoSidebar items={items} />
+      </ArdoProvider>
+    </MemoryRouter>
+  )
+}
+
+describe("ArdoSidebar", () => {
+  it("connects collapsed group toggles to inert content", () => {
+    const view = renderSidebar([
+      {
+        text: "Guide",
+        collapsed: true,
+        items: [{ text: "Getting Started", link: "/guide/getting-started" }],
+      },
+    ])
+    const toggle =
+      /<button[^>]*aria-expanded="false"[^>]*aria-controls="([^"]+)"[^>]*aria-label="Expand Guide"/.exec(
+        view
+      )
+
+    expect(toggle).not.toBeNull()
+    expect(view).toContain(`id="${toggle?.[1]}"`)
+    expect(view).toContain('aria-hidden="true"')
+    expect(view).toContain("inert")
+  })
+
+  it("renders unlinked groups with a single toggle button", () => {
+    const view = renderSidebar([
+      {
+        text: "API",
+        items: [{ text: "Reference", link: "/api-reference" }],
+      },
+    ])
+
+    expect(view.match(/<button/g)).toHaveLength(1)
+    expect(view).toContain('aria-expanded="true"')
+    expect(view).toContain('aria-label="Collapse API"')
+  })
+})

--- a/packages/ardo/src/ui/Sidebar.tsx
+++ b/packages/ardo/src/ui/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   type ReactElement,
   type ReactNode,
   use,
+  useId,
   useMemo,
   useState,
 } from "react"
@@ -177,6 +178,7 @@ export function ArdoSidebarGroup({
 }: ArdoSidebarGroupProps) {
   const [collapsed, setCollapsed] = useState(initialCollapsed)
   const { currentPath } = useSidebarContext()
+  const contentId = useId()
 
   // Check if any child is active
   const hasActiveChild = checkChildrenActive(children, currentPath)
@@ -189,6 +191,7 @@ export function ArdoSidebarGroup({
   const hasChildren = Children.count(children) > 0
   const hasTo = (to ?? "") !== ""
   const canToggle = collapsible && hasChildren
+  const toggleLabel = `${collapsed ? "Expand" : "Collapse"} ${title}`
 
   const itemClassName =
     className ??
@@ -207,28 +210,34 @@ export function ArdoSidebarGroup({
           >
             {title}
           </NavLink>
-        ) : (
+        ) : canToggle ? (
           <button
             type="button"
             className={textButtonClassName}
             onClick={() => {
-              if (canToggle) {
-                setCollapsed(!collapsed)
-              }
+              setCollapsed(!collapsed)
             }}
+            aria-expanded={!collapsed}
+            aria-controls={contentId}
+            aria-label={toggleLabel}
           >
-            {title}
+            <span>{title}</span>
+            <CollapseChevron collapsed={collapsed} />
           </button>
+        ) : (
+          <span className={textClassName}>{title}</span>
         )}
 
-        {canToggle && (
+        {canToggle && hasTo && (
           <button
             type="button"
             className={[styles.sidebarCollapse, collapsed && "collapsed"].filter(Boolean).join(" ")}
             onClick={() => {
               setCollapsed(!collapsed)
             }}
-            aria-label={collapsed ? "Expand" : "Collapse"}
+            aria-label={toggleLabel}
+            aria-expanded={!collapsed}
+            aria-controls={contentId}
           >
             <ChevronDownIcon size={16} />
           </button>
@@ -236,7 +245,13 @@ export function ArdoSidebarGroup({
       </div>
 
       {hasChildren && (
-        <div className={styles.sidebarCollapseWrapper} data-collapsed={collapsed}>
+        <div
+          id={contentId}
+          className={styles.sidebarCollapseWrapper}
+          data-collapsed={collapsed}
+          aria-hidden={collapsed}
+          inert={collapsed}
+        >
           <div className={styles.sidebarCollapseInner}>
             <ul className={`${styles.sidebarList} ${styles.sidebarList1}`}>{children}</ul>
           </div>
@@ -316,6 +331,7 @@ type SidebarItemComponentProps = {
 function SidebarItemComponent({ item, depth }: SidebarItemComponentProps) {
   const { currentPath } = useSidebarContext()
   const [collapsed, setCollapsed] = useState(item.collapsed ?? false)
+  const contentId = useId()
   const childItems = item.items ?? []
 
   const hasChildren = childItems.length > 0
@@ -337,6 +353,7 @@ function SidebarItemComponent({ item, depth }: SidebarItemComponentProps) {
     .filter(Boolean)
     .join(" ")
   const textButtonClassName = [textClassName, styles.sidebarTextButton].join(" ")
+  const toggleLabel = `${collapsed ? "Expand" : "Collapse"} ${item.text}`
 
   const itemClassName = [styles.sidebarItem, hasChildren && styles.sidebarItemGroup]
     .filter(Boolean)
@@ -354,28 +371,34 @@ function SidebarItemComponent({ item, depth }: SidebarItemComponentProps) {
           >
             {item.text}
           </NavLink>
-        ) : (
+        ) : hasChildren ? (
           <button
             type="button"
             className={textButtonClassName}
             onClick={() => {
-              if (hasChildren) {
-                setCollapsed(!collapsed)
-              }
+              setCollapsed(!collapsed)
             }}
+            aria-expanded={!collapsed}
+            aria-controls={contentId}
+            aria-label={toggleLabel}
           >
-            {item.text}
+            <span>{item.text}</span>
+            <CollapseChevron collapsed={collapsed} />
           </button>
+        ) : (
+          <span className={textClassName}>{item.text}</span>
         )}
 
-        {hasChildren && (
+        {hasChildren && hasItemLink && (
           <button
             type="button"
             className={[styles.sidebarCollapse, collapsed && "collapsed"].filter(Boolean).join(" ")}
             onClick={() => {
               setCollapsed(!collapsed)
             }}
-            aria-label={collapsed ? "Expand" : "Collapse"}
+            aria-label={toggleLabel}
+            aria-expanded={!collapsed}
+            aria-controls={contentId}
           >
             <ChevronDownIcon size={16} />
           </button>
@@ -383,13 +406,30 @@ function SidebarItemComponent({ item, depth }: SidebarItemComponentProps) {
       </div>
 
       {hasChildren && (
-        <div className={styles.sidebarCollapseWrapper} data-collapsed={collapsed}>
+        <div
+          id={contentId}
+          className={styles.sidebarCollapseWrapper}
+          data-collapsed={collapsed}
+          aria-hidden={collapsed}
+          inert={collapsed}
+        >
           <div className={styles.sidebarCollapseInner}>
             <SidebarItems items={childItems} depth={depth + 1} />
           </div>
         </div>
       )}
     </li>
+  )
+}
+
+function CollapseChevron({ collapsed }: { collapsed: boolean }) {
+  return (
+    <span
+      className={[styles.sidebarToggleChevron, collapsed && "collapsed"].filter(Boolean).join(" ")}
+      aria-hidden="true"
+    >
+      <ChevronDownIcon size={16} />
+    </span>
   )
 }
 

--- a/packages/ardo/src/ui/components/HeaderSearch.tsx
+++ b/packages/ardo/src/ui/components/HeaderSearch.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useLocation } from "react-router"
 
 import { SearchIcon, XIcon } from "../icons"
+import { focusInitialElement, trapFocus } from "../mobile-drawer-a11y"
 import * as styles from "./HeaderSearch.css"
 import { ArdoSearch, type ArdoSearchProps } from "./Search"
 
@@ -13,22 +14,23 @@ import { ArdoSearch, type ArdoSearchProps } from "./Search"
 export function ArdoHeaderSearch({ placeholder }: ArdoSearchProps) {
   const [overlayOpen, setOverlayOpen] = useState(false)
   const location = useLocation()
+  const overlayRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const closeOverlay = useCallback(() => {
+    setOverlayOpen(false)
+  }, [])
 
-  // Close the overlay on navigation and on Escape.
+  // Close the overlay on navigation.
   useEffect(() => {
     setOverlayOpen(false)
   }, [location.pathname])
 
-  useEffect(() => {
-    if (!overlayOpen) return
-    const handleKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setOverlayOpen(false)
-    }
-    document.addEventListener("keydown", handleKey)
-    return () => {
-      document.removeEventListener("keydown", handleKey)
-    }
-  }, [overlayOpen])
+  useSearchOverlayFocus({
+    onClose: closeOverlay,
+    open: overlayOpen,
+    overlayRef,
+    triggerRef,
+  })
 
   return (
     <>
@@ -37,9 +39,11 @@ export function ArdoHeaderSearch({ placeholder }: ArdoSearchProps) {
       </div>
 
       <button
+        ref={triggerRef}
         type="button"
         className={styles.trigger}
         aria-label="Search"
+        aria-expanded={overlayOpen}
         onClick={() => {
           setOverlayOpen(true)
         }}
@@ -48,7 +52,14 @@ export function ArdoHeaderSearch({ placeholder }: ArdoSearchProps) {
       </button>
 
       {overlayOpen && (
-        <div className={styles.overlay}>
+        <div
+          ref={overlayRef}
+          className={styles.overlay}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Search"
+          tabIndex={-1}
+        >
           <div className={styles.overlayBar}>
             <div className={styles.overlaySearch}>
               <ArdoSearch placeholder={placeholder} autoFocus />
@@ -57,9 +68,7 @@ export function ArdoHeaderSearch({ placeholder }: ArdoSearchProps) {
               type="button"
               className={styles.overlayClose}
               aria-label="Close search"
-              onClick={() => {
-                setOverlayOpen(false)
-              }}
+              onClick={closeOverlay}
             >
               <XIcon size={20} />
             </button>
@@ -68,4 +77,49 @@ export function ArdoHeaderSearch({ placeholder }: ArdoSearchProps) {
       )}
     </>
   )
+}
+
+function useSearchOverlayFocus({
+  onClose,
+  open,
+  overlayRef,
+  triggerRef,
+}: {
+  onClose: () => void
+  open: boolean
+  overlayRef: React.RefObject<HTMLDivElement | null>
+  triggerRef: React.RefObject<HTMLButtonElement | null>
+}) {
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const overlay = overlayRef.current
+    const triggerElement = triggerRef.current
+    document.body.style.overflow = "hidden"
+
+    if (overlay != null) {
+      focusInitialElement(overlay)
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault()
+        onClose()
+        return
+      }
+
+      if (event.key === "Tab" && overlay != null) {
+        trapFocus(event, overlay)
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown)
+    return () => {
+      document.body.style.overflow = ""
+      document.removeEventListener("keydown", handleKeyDown)
+      triggerElement?.focus()
+    }
+  }, [onClose, open, overlayRef, triggerRef])
 }

--- a/packages/ardo/src/ui/components/SearchPopover.tsx
+++ b/packages/ardo/src/ui/components/SearchPopover.tsx
@@ -17,14 +17,31 @@ export function SearchPopover({
   const [pos, setPos] = useState({ top: 0, left: 0, width: 0 })
 
   useLayoutEffect(() => {
-    const el = anchorRef.current
-    if (!el) return
-    const rect = el.getBoundingClientRect()
-    setPos({
-      top: rect.bottom + 8,
-      left: rect.left,
-      width: Math.max(rect.width, 400),
-    })
+    const updatePosition = () => {
+      const el = anchorRef.current
+      if (el == null) {
+        return
+      }
+
+      const rect = el.getBoundingClientRect()
+      const viewportWidth = globalThis.innerWidth
+      const maxWidth = Math.max(viewportWidth - 32, 0)
+      const width = Math.min(Math.max(rect.width, 400), maxWidth)
+      const maxLeft = Math.max(viewportWidth - width - 16, 0)
+      setPos({
+        top: rect.bottom + 8,
+        left: Math.min(Math.max(rect.left, 16), maxLeft),
+        width,
+      })
+    }
+
+    updatePosition()
+    globalThis.addEventListener("resize", updatePosition)
+    globalThis.addEventListener("scroll", updatePosition, true)
+    return () => {
+      globalThis.removeEventListener("resize", updatePosition)
+      globalThis.removeEventListener("scroll", updatePosition, true)
+    }
   }, [anchorRef])
 
   if (typeof document === "undefined") return null
@@ -35,7 +52,7 @@ export function SearchPopover({
       style={{
         top: pos.top,
         left: pos.left,
-        width: Math.min(pos.width, globalThis.innerWidth - 32),
+        width: pos.width,
       }}
     >
       {children}

--- a/packages/ardo/src/ui/components/SearchResults.tsx
+++ b/packages/ardo/src/ui/components/SearchResults.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react"
 import { Link } from "react-router"
 
 import { ArdoOwlMark } from "../OwlMark"
@@ -25,10 +26,18 @@ export function SearchResults({
   query: string
   onClose: () => void
 }) {
+  const resultsRef = useRef<HTMLUListElement>(null)
+
+  useEffect(() => {
+    const selectedOption = resultsRef.current?.querySelector<HTMLElement>('[aria-selected="true"]')
+    selectedOption?.scrollIntoView({ block: "nearest" })
+  }, [selectedIndex])
+
   return (
     <>
       {results.length > 0 ? (
         <ul
+          ref={resultsRef}
           id={listboxId}
           className={styles.searchResults}
           role="listbox"

--- a/packages/ardo/src/ui/mobile-drawer-a11y.test.ts
+++ b/packages/ardo/src/ui/mobile-drawer-a11y.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, it } from "vitest"
 
-import { getTrappedFocusTarget } from "./mobile-drawer-a11y"
+import type { FocusableElementCandidate } from "./mobile-drawer-a11y"
+
+import { getTrappedFocusTarget, isFocusableElement } from "./mobile-drawer-a11y"
+
+type TestFocusableElement = {
+  testId: string
+} & FocusableElementCandidate
+
+function createFocusableElement({
+  ariaHidden,
+  disabled = false,
+  inert = false,
+  testId,
+}: {
+  ariaHidden?: string
+  disabled?: boolean
+  inert?: boolean
+  testId: string
+}): TestFocusableElement {
+  return {
+    closest: (selector) => (selector === "[inert]" && inert ? {} : null),
+    getAttribute: (name) => (name === "aria-hidden" ? (ariaHidden ?? null) : null),
+    hasAttribute: (name) => name === "disabled" && disabled,
+    testId,
+  }
+}
 
 describe("mobile drawer accessibility helpers", () => {
   const focusableElements = ["close", "link", "theme"]
@@ -33,5 +58,20 @@ describe("mobile drawer accessibility helpers", () => {
         shiftKey: false,
       })
     ).toBeUndefined()
+  })
+
+  it("excludes disabled, aria-hidden, and inert subtree elements from focus traps", () => {
+    const elements = [
+      createFocusableElement({ testId: "close" }),
+      createFocusableElement({ inert: true, testId: "hidden-link" }),
+      createFocusableElement({ ariaHidden: "true", testId: "hidden-button" }),
+      createFocusableElement({ disabled: true, testId: "disabled-button" }),
+      createFocusableElement({ testId: "visible-link" }),
+    ]
+
+    expect(elements.filter(isFocusableElement).map((element) => element.testId)).toStrictEqual([
+      "close",
+      "visible-link",
+    ])
   })
 })

--- a/packages/ardo/src/ui/mobile-drawer-a11y.ts
+++ b/packages/ardo/src/ui/mobile-drawer-a11y.ts
@@ -1,3 +1,12 @@
+export const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",")
+
 export function getTrappedFocusTarget<T>({
   activeElement,
   focusableElements,
@@ -21,4 +30,34 @@ export function getTrappedFocusTarget<T>({
   if (!shiftKey && activeElement === lastElement) {
     return firstElement
   }
+}
+
+export function getFocusableElements(container: ParentNode): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
+    (element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true"
+  )
+}
+
+export function focusInitialElement(container: HTMLElement): void {
+  const focusableElements = getFocusableElements(container)
+  const initialFocusTarget = focusableElements[0] ?? container
+  initialFocusTarget.focus()
+}
+
+export function trapFocus(event: KeyboardEvent, container: HTMLElement): void {
+  const focusableElements = getFocusableElements(container)
+  const activeElement =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null
+  const target = getTrappedFocusTarget({
+    activeElement,
+    focusableElements,
+    shiftKey: event.shiftKey,
+  })
+
+  if (target == null) {
+    return
+  }
+
+  event.preventDefault()
+  target.focus()
 }

--- a/packages/ardo/src/ui/mobile-drawer-a11y.ts
+++ b/packages/ardo/src/ui/mobile-drawer-a11y.ts
@@ -7,6 +7,12 @@ export const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(",")
 
+export type FocusableElementCandidate = {
+  closest: (selectors: string) => unknown
+  getAttribute: (qualifiedName: string) => null | string
+  hasAttribute: (qualifiedName: string) => boolean
+}
+
 export function getTrappedFocusTarget<T>({
   activeElement,
   focusableElements,
@@ -32,9 +38,17 @@ export function getTrappedFocusTarget<T>({
   }
 }
 
+export function isFocusableElement(element: FocusableElementCandidate): boolean {
+  return (
+    !element.hasAttribute("disabled") &&
+    element.getAttribute("aria-hidden") !== "true" &&
+    element.closest("[inert]") == null
+  )
+}
+
 export function getFocusableElements(container: ParentNode): HTMLElement[] {
-  return [...container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(
-    (element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true"
+  return [...container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter((element) =>
+    isFocusableElement(element)
   )
 }
 


### PR DESCRIPTION
## Summary
- render both light and dark logo variants through a shared header logo component
- keep the search popover viewport-bound and keep keyboard-selected results visible
- give the mobile search overlay dialog semantics, focus trapping, Escape close, body scroll lock, and trigger focus restore
- expose sidebar collapse state through aria-expanded/aria-controls and hide collapsed content from assistive tech

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm lint (0 errors; existing warnings remain)
- pnpm build
- pnpm test
- pnpm docs:build (passes; existing generated API/demo broken-link warnings remain)

Closes #219
Closes #220
Closes #221
Closes #222
Refs #246