### PR TITLE
Improve create-ardo scripted scaffolding

### DIFF
--- a/packages/create-ardo/README.md
+++ b/packages/create-ardo/README.md
@@ -29,8 +29,17 @@ pnpm create ardo@latest my-docs
 ### Non-interactive
 
 ```bash
-pnpm create ardo@latest my-docs minimal
+pnpm create ardo@latest my-docs minimal --yes --title "My Documentation" --no-github-pages
 ```
+
+Available flags:
+
+- `--yes` uses defaults without prompting.
+- `--title <title>` sets the site title.
+- `--typedoc` / `--no-typedoc` toggles TypeDoc API page generation.
+- `--github-pages` / `--no-github-pages` toggles the generated GitHub Pages config.
+
+When stdin is not a TTY, `create-ardo` automatically uses non-interactive defaults.
 
 ## What gets created
 
@@ -51,7 +60,7 @@ my-docs/
 ├── react-router.config.ts      # Static prerender config
 ├── tsconfig.json
 ├── package.json
-└── pnpm-workspace.yaml
+└── pnpm-workspace.yaml        # pnpm only
 ```
 
 ## After creation
@@ -61,6 +70,8 @@ cd my-docs
 pnpm install
 pnpm dev
 ```
+
+If you scaffold through `npm create`, `yarn create`, or `bun create`, the generated next steps and GitHub Pages workflow use that package manager instead.
 
 Open `http://localhost:5173`, add MDX files under `app/routes/`, and Ardo will include them in the generated docs navigation.
 

--- a/packages/create-ardo/src/cli-options.test.ts
+++ b/packages/create-ardo/src/cli-options.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import { parseCliArgs } from "./cli-options"
+
+describe("parseCliArgs", () => {
+  it("parses positional target/template and non-interactive flags", () => {
+    expect(
+      parseCliArgs([
+        "my-docs",
+        "minimal",
+        "--yes",
+        "--title",
+        "Docs",
+        "--typedoc",
+        "--no-github-pages",
+      ])
+    ).toStrictEqual({
+      githubPages: false,
+      help: false,
+      siteTitle: "Docs",
+      targetDir: "my-docs",
+      template: "minimal",
+      typedoc: true,
+      yes: true,
+    })
+  })
+
+  it("rejects unknown flags", () => {
+    expect(() => parseCliArgs(["--wat"])).toThrow("Unknown option: --wat")
+  })
+})

--- a/packages/create-ardo/src/cli-options.ts
+++ b/packages/create-ardo/src/cli-options.ts
@@ -1,0 +1,112 @@
+export type CliOptions = {
+  githubPages?: boolean
+  help: boolean
+  siteTitle?: string
+  targetDir?: string
+  template?: string
+  typedoc?: boolean
+  yes: boolean
+}
+
+export function parseCliArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    help: false,
+    yes: false,
+  }
+  const positionals: string[] = []
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--") {
+      positionals.push(...argv.slice(index + 1))
+      break
+    }
+
+    if (arg.startsWith("-")) {
+      index += applyOption({ arg, argv, index, options })
+    } else {
+      positionals.push(arg)
+    }
+  }
+
+  assignPositionals(options, positionals)
+  return options
+}
+
+type ApplyOptionInput = {
+  arg: string
+  argv: string[]
+  index: number
+  options: CliOptions
+}
+
+function applyOption({ arg, argv, index, options }: ApplyOptionInput): number {
+  if (arg.startsWith("--title=")) {
+    options.siteTitle = arg.slice("--title=".length)
+    return 0
+  }
+
+  switch (arg) {
+    case "--github-pages":
+      options.githubPages = true
+      return 0
+    case "--help":
+    case "-h":
+      options.help = true
+      return 0
+    case "--no-github-pages":
+      options.githubPages = false
+      return 0
+    case "--no-typedoc":
+      options.typedoc = false
+      return 0
+    case "--title":
+      options.siteTitle = readRequiredValue(argv, index, "--title")
+      return 1
+    case "--typedoc":
+      options.typedoc = true
+      return 0
+    case "--yes":
+    case "-y":
+      options.yes = true
+      return 0
+    default:
+      throw new Error(`Unknown option: ${arg}`)
+  }
+}
+
+function readRequiredValue(argv: string[], index: number, flag: string): string {
+  if (index + 1 >= argv.length) {
+    throw new Error(`${flag} requires a value`)
+  }
+  const value = argv[index + 1]
+  if (value.startsWith("-")) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return value
+}
+
+function assignPositionals(options: CliOptions, positionals: string[]): void {
+  if (positionals.length > 2) {
+    throw new Error(`Unexpected argument: ${positionals[2]}`)
+  }
+
+  options.targetDir = positionals[0]
+  options.template = positionals[1]
+}
+
+export function getHelpText(): string {
+  return [
+    "Usage:",
+    "  create-ardo [target-directory] [template] [options]",
+    "",
+    "Options:",
+    "  -y, --yes                 Use defaults without prompting",
+    "      --title <title>       Set the site title",
+    "      --typedoc             Enable TypeDoc API pages",
+    "      --no-typedoc          Disable TypeDoc API pages",
+    "      --github-pages        Enable GitHub Pages config",
+    "      --no-github-pages     Disable GitHub Pages config",
+    "  -h, --help                Show this help",
+  ].join("\n")
+}

--- a/packages/create-ardo/src/index.ts
+++ b/packages/create-ardo/src/index.ts
@@ -3,8 +3,11 @@ import fs from "node:fs"
 import path from "node:path"
 import prompts from "prompts"
 
+import { type CliOptions, getHelpText, parseCliArgs } from "./cli-options"
+import { detectPackageManager, getPackageManagerCommands } from "./package-manager"
 import {
   createProjectStructure,
+  derivePackageName,
   detectProjectDescription,
   emptyDir,
   formatTargetDir,
@@ -14,6 +17,7 @@ import {
   isValidTemplate,
   templates,
   upgradeProject,
+  validateTargetDir,
 } from "./scaffold"
 
 const defaultTargetDir = "my-docs"
@@ -30,6 +34,28 @@ type NewProjectPromptResponse = {
   githubPages?: boolean
 }
 
+type NewProjectPromptContext = {
+  argTemplate: string | undefined
+  cliOptions: CliOptions
+  root: string
+  targetDir: string
+}
+
+type NewProjectFlowContext = {
+  cliOptions: CliOptions
+  nonInteractive: boolean
+  root: string
+  targetDir: string
+}
+
+type NewProjectSettings = {
+  githubPages: boolean
+  packageManager: ReturnType<typeof detectPackageManager>
+  siteTitle: string
+  template: string
+  typedoc: boolean
+}
+
 async function promptProjectName(): Promise<string> {
   const nameResponse = await prompts<"projectName">(
     {
@@ -38,12 +64,7 @@ async function promptProjectName(): Promise<string> {
       message: reset("Project name:"),
       initial: defaultTargetDir,
       validate(value: string) {
-        const name = value.trim()
-        if (!name) return "Project name is required"
-        if (/^[.-]/.test(name)) return "Project name cannot start with a dot or hyphen"
-        if (!/^[\da-z-]+$/.test(name))
-          return "Project name may only contain lowercase letters, digits, and hyphens"
-        return true
+        return validateTargetDir(value)
       },
     },
     { onCancel }
@@ -86,7 +107,8 @@ async function runUpgradeFlow(root: string): Promise<void> {
   console.log(`  ${blue("pnpm install")}\n`)
 }
 
-function getNewProjectPrompts(targetDir: string, root: string, argTemplate: string | undefined) {
+function getNewProjectPrompts(context: NewProjectPromptContext) {
+  const { argTemplate, cliOptions, root, targetDir } = context
   return [
     {
       type: (): "select" | null => (!fs.existsSync(root) || isEmpty(root) ? null : "select"),
@@ -116,13 +138,13 @@ function getNewProjectPrompts(targetDir: string, root: string, argTemplate: stri
       })),
     },
     {
-      type: "text" as const,
+      type: cliOptions.siteTitle === undefined ? ("text" as const) : null,
       name: "siteTitle",
       message: reset("Site title:"),
       initial: "My Documentation",
     },
     {
-      type: "select" as const,
+      type: cliOptions.typedoc === undefined ? ("select" as const) : null,
       name: "docType",
       message: reset("What are you documenting?"),
       choices: [
@@ -131,7 +153,7 @@ function getNewProjectPrompts(targetDir: string, root: string, argTemplate: stri
       ],
     },
     {
-      type: "select" as const,
+      type: cliOptions.githubPages === undefined ? ("select" as const) : null,
       name: "githubPages",
       message: reset("Deploy to GitHub Pages?"),
       choices: [
@@ -142,37 +164,75 @@ function getNewProjectPrompts(targetDir: string, root: string, argTemplate: stri
   ]
 }
 
-async function runNewProjectFlow(
-  targetDir: string,
-  root: string,
-  argTemplate: string | undefined
-): Promise<void> {
-  const questions = getNewProjectPrompts(targetDir, root, argTemplate)
-  const responseData: unknown = await prompts(questions, { onCancel })
+async function runNewProjectFlow(context: NewProjectFlowContext): Promise<void> {
+  const { cliOptions, nonInteractive, root, targetDir } = context
+  const argTemplate = cliOptions.template
+  validateNewProjectStart(context, argTemplate)
+  const questions = getNewProjectPrompts({ argTemplate, cliOptions, root, targetDir })
+  const responseData: unknown = nonInteractive ? {} : await prompts(questions, { onCancel })
   const response = readNewProjectPromptResponse(responseData)
+  const settings = resolveNewProjectSettings(cliOptions, response)
 
-  const template = response.template ?? argTemplate ?? "minimal"
+  prepareTargetDirectory(root, response)
 
+  console.log(`\n  ${cyan("Scaffolding project in")} ${root}...\n`)
+  createProjectStructure(root, settings.template, {
+    siteTitle: settings.siteTitle,
+    projectName: derivePackageName(targetDir, root),
+    typedoc: settings.typedoc,
+    githubPages: settings.githubPages,
+    description: detectProjectDescription(root) ?? "Built with Ardo",
+    packageManager: settings.packageManager,
+    overwriteExisting: response.overwrite !== "ignore",
+  })
+
+  printNextSteps(targetDir, root, settings.packageManager)
+}
+
+function validateNewProjectStart(
+  { nonInteractive, root, targetDir }: NewProjectFlowContext,
+  argTemplate: string | undefined
+): void {
+  if (argTemplate !== undefined && !isValidTemplate(argTemplate) && nonInteractive) {
+    throw new Error(`${red("✖")} Unknown template: ${argTemplate}`)
+  }
+
+  if (nonInteractive && fs.existsSync(root) && !isEmpty(root)) {
+    throw new Error(`${red("✖")} Target directory is not empty: ${targetDir}`)
+  }
+}
+
+function resolveNewProjectSettings(
+  cliOptions: CliOptions,
+  response: NewProjectPromptResponse
+): NewProjectSettings {
+  return {
+    githubPages: cliOptions.githubPages ?? response.githubPages ?? true,
+    packageManager: detectPackageManager(),
+    siteTitle: cliOptions.siteTitle ?? response.siteTitle,
+    template: response.template ?? cliOptions.template ?? "minimal",
+    typedoc: cliOptions.typedoc ?? response.docType === "library",
+  }
+}
+
+function prepareTargetDirectory(root: string, response: NewProjectPromptResponse): void {
   if (response.overwrite === "yes") {
     emptyDir(root)
   } else if (!fs.existsSync(root)) {
     fs.mkdirSync(root, { recursive: true })
   }
+}
 
-  console.log(`\n  ${cyan("Scaffolding project in")} ${root}...\n`)
-  createProjectStructure(root, template, {
-    siteTitle: response.siteTitle,
-    projectName: targetDir,
-    typedoc: response.docType === "library",
-    githubPages: response.githubPages ?? true,
-    description: detectProjectDescription(root) ?? "Built with Ardo",
-    overwriteExisting: response.overwrite !== "ignore",
-  })
-
+function printNextSteps(
+  targetDir: string,
+  root: string,
+  packageManager: NewProjectSettings["packageManager"]
+): void {
   console.log(`  ${green("Done!")} Now run:\n`)
   if (root !== process.cwd()) console.log(`  ${blue("cd")} ${targetDir}`)
-  console.log(`  ${blue("pnpm install")}`)
-  console.log(`  ${blue("pnpm dev")}\n`)
+  const commands = getPackageManagerCommands(packageManager)
+  console.log(`  ${blue(commands.install)}`)
+  console.log(`  ${blue(commands.dev)}\n`)
 }
 
 function readNewProjectPromptResponse(data: unknown): NewProjectPromptResponse {
@@ -201,11 +261,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 async function main() {
+  const cliOptions = parseCliArgs(process.argv.slice(2))
+  if (cliOptions.help) {
+    console.log(getHelpText())
+    return
+  }
+
   console.log(`\n  ${cyan("◆")} ${green("create-ardo")}\n`)
 
-  const argTargetDir = process.argv.length > 2 ? process.argv[2] : undefined
-  const argTemplate = process.argv.length > 3 ? process.argv[3] : undefined
-  const targetDir = argTargetDir ?? (await promptProjectName())
+  const nonInteractive = cliOptions.yes || !process.stdin.isTTY
+  const targetDir = await resolveTargetDir(cliOptions, nonInteractive)
   const root = path.join(process.cwd(), targetDir)
 
   if (fs.existsSync(root) && !isEmpty(root) && isArdoProject(root)) {
@@ -213,7 +278,17 @@ async function main() {
     return
   }
 
-  await runNewProjectFlow(targetDir, root, argTemplate)
+  await runNewProjectFlow({ cliOptions, nonInteractive, root, targetDir })
+}
+
+async function resolveTargetDir(cliOptions: CliOptions, nonInteractive: boolean): Promise<string> {
+  const argTargetDir = formatTargetDir(cliOptions.targetDir)
+  const targetDir = argTargetDir ?? (nonInteractive ? defaultTargetDir : await promptProjectName())
+  const targetDirValidation = validateTargetDir(targetDir)
+  if (targetDirValidation !== true) {
+    throw new Error(`${red("✖")} ${targetDirValidation}`)
+  }
+  return targetDir
 }
 
 try {

--- a/packages/create-ardo/src/package-manager.test.ts
+++ b/packages/create-ardo/src/package-manager.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { detectPackageManager, getPackageManagerCommands } from "./package-manager"
+
+describe("detectPackageManager", () => {
+  it.each([
+    ["pnpm/11.2.2 npm/? node/v24.0.0", "pnpm"],
+    ["npm/11.0.0 node/v24.0.0", "npm"],
+    ["yarn/4.0.0 npm/? node/v24.0.0", "yarn"],
+    ["bun/1.2.0 npm/? node/v24.0.0", "bun"],
+    [undefined, "pnpm"],
+  ] as const)("detects %s as %s", (userAgent, expected) => {
+    expect(detectPackageManager(userAgent)).toBe(expected)
+  })
+})
+
+describe("getPackageManagerCommands", () => {
+  it("uses package-manager specific run commands", () => {
+    expect(getPackageManagerCommands("npm").dev).toBe("npm run dev")
+    expect(getPackageManagerCommands("yarn").workflowInstall).toBe("yarn install --immutable")
+    expect(getPackageManagerCommands("bun").workflowSetup).toContain("oven-sh/setup-bun")
+  })
+})

--- a/packages/create-ardo/src/package-manager.ts
+++ b/packages/create-ardo/src/package-manager.ts
@@ -1,0 +1,73 @@
+export type PackageManager = "bun" | "npm" | "pnpm" | "yarn"
+
+export type PackageManagerCommands = {
+  build: string
+  dev: string
+  install: string
+  preview: string
+  workflowBuild: string
+  workflowInstall: string
+  workflowSetup: string
+  workflowSetupNodeCache: string
+}
+
+export function detectPackageManager(
+  userAgent = process.env.npm_config_user_agent
+): PackageManager {
+  const name = userAgent?.split(" ")[0]?.split("/")[0]
+  if (name === "bun" || name === "npm" || name === "pnpm" || name === "yarn") {
+    return name
+  }
+  return "pnpm"
+}
+
+export function getPackageManagerCommands(packageManager: PackageManager): PackageManagerCommands {
+  switch (packageManager) {
+    case "bun":
+      return {
+        build: "bun run build",
+        dev: "bun run dev",
+        install: "bun install",
+        preview: "bun run preview",
+        workflowBuild: "bun run build",
+        workflowInstall: "bun install --frozen-lockfile",
+        workflowSetup: ["      - name: Setup Bun", "        uses: oven-sh/setup-bun@v2"].join("\n"),
+        workflowSetupNodeCache: "",
+      }
+    case "npm":
+      return {
+        build: "npm run build",
+        dev: "npm run dev",
+        install: "npm install",
+        preview: "npm run preview",
+        workflowBuild: "npm run build",
+        workflowInstall: "npm ci",
+        workflowSetup: "",
+        workflowSetupNodeCache: "          cache: 'npm'",
+      }
+    case "yarn":
+      return {
+        build: "yarn build",
+        dev: "yarn dev",
+        install: "yarn install",
+        preview: "yarn preview",
+        workflowBuild: "yarn build",
+        workflowInstall: "yarn install --immutable",
+        workflowSetup: ["      - name: Enable Corepack", "        run: corepack enable"].join("\n"),
+        workflowSetupNodeCache: "          cache: 'yarn'",
+      }
+    case "pnpm":
+      return {
+        build: "pnpm build",
+        dev: "pnpm dev",
+        install: "pnpm install",
+        preview: "pnpm preview",
+        workflowBuild: "pnpm build",
+        workflowInstall: "pnpm install --frozen-lockfile",
+        workflowSetup: ["      - name: Setup pnpm", "        uses: pnpm/action-setup@v4"].join(
+          "\n"
+        ),
+        workflowSetupNodeCache: "          cache: 'pnpm'",
+      }
+  }
+}

--- a/packages/create-ardo/src/scaffold.test.ts
+++ b/packages/create-ardo/src/scaffold.test.ts
@@ -3,7 +3,7 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
-import { createProjectStructure, upgradeProject } from "./scaffold"
+import { createProjectStructure, derivePackageName, upgradeProject } from "./scaffold"
 
 let tmpDir: string
 
@@ -52,6 +52,38 @@ describe("createProjectStructure", () => {
     expect(fs.readFileSync(path.join(tmpDir, "package.json"), "utf8")).toBe('{"name":"keep-me"}\n')
     expect(fs.readFileSync(path.join(tmpDir, "app", "root.tsx"), "utf8")).toBe("// customized\n")
     expect(fs.existsSync(path.join(tmpDir, "vite.config.ts"))).toBe(true)
+  })
+
+  it("derives a valid package name from the target directory basename", () => {
+    expect(derivePackageName("My Docs/")).toBe("my-docs")
+    expect(derivePackageName("docs/site")).toBe("site")
+    expect(derivePackageName("---")).toBe("my-docs")
+  })
+
+  it("adapts generated workflow and files to the selected package manager", () => {
+    createProjectStructure(tmpDir, "minimal", {
+      siteTitle: "Docs",
+      projectName: "docs-site",
+      typedoc: false,
+      githubPages: true,
+      description: "Built with Ardo",
+      packageManager: "npm",
+    })
+
+    const workflow = fs.readFileSync(
+      path.join(tmpDir, ".github", "workflows", "deploy.yml"),
+      "utf8"
+    )
+    const gettingStarted = fs.readFileSync(
+      path.join(tmpDir, "app", "routes", "guide", "getting-started.mdx"),
+      "utf8"
+    )
+
+    expect(fs.existsSync(path.join(tmpDir, "pnpm-workspace.yaml"))).toBe(false)
+    expect(workflow).toContain("cache: 'npm'")
+    expect(workflow).toContain("run: npm ci")
+    expect(workflow).toContain("run: npm run build")
+    expect(gettingStarted).toContain("npm run dev")
   })
 })
 

--- a/packages/create-ardo/src/scaffold.ts
+++ b/packages/create-ardo/src/scaffold.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs"
 import path from "node:path"
 
+import { getPackageManagerCommands, type PackageManager } from "./package-manager"
+
 const __dirname = import.meta.dirname
 const templatesRoot = path.resolve(__dirname, "..", "templates")
 const packageJsonPath = path.resolve(__dirname, "..", "package.json")
@@ -26,11 +28,13 @@ export type ScaffoldOptions = {
   typedoc: boolean
   githubPages: boolean
   description: string
+  packageManager?: PackageManager
   overwriteExisting?: boolean
 }
 
 type CopyContext = {
   overwriteExisting: boolean
+  packageManager: PackageManager
   vars: Record<string, string>
 }
 
@@ -42,10 +46,20 @@ type CopyEntryInput = {
 
 export function createProjectStructure(root: string, template: string, options: ScaffoldOptions) {
   const templateDir = path.join(templatesRoot, template)
+  const packageManager = options.packageManager ?? "pnpm"
+  const commands = getPackageManagerCommands(packageManager)
   const vars: Record<string, string> = {
     SITE_TITLE: escapeTemplateValue(options.siteTitle),
     PROJECT_NAME: escapeTemplateValue(options.projectName),
     ARDO_VERSION: getCliVersion(),
+    PACKAGE_MANAGER_BUILD: commands.build,
+    PACKAGE_MANAGER_DEV: commands.dev,
+    PACKAGE_MANAGER_INSTALL: commands.install,
+    PACKAGE_MANAGER_PREVIEW: commands.preview,
+    WORKFLOW_BUILD_COMMAND: commands.workflowBuild,
+    WORKFLOW_INSTALL_COMMAND: commands.workflowInstall,
+    WORKFLOW_PACKAGE_MANAGER_SETUP: commands.workflowSetup,
+    WORKFLOW_SETUP_NODE_CACHE: commands.workflowSetupNodeCache,
     TYPEDOC_CONFIG: options.typedoc
       ? "typedoc: true,"
       : "// typedoc: true, // Uncomment to enable API docs",
@@ -61,7 +75,11 @@ export function createProjectStructure(root: string, template: string, options: 
     DESCRIPTION: escapeTemplateValue(options.description),
   }
 
-  copyDir(templateDir, root, { vars, overwriteExisting: options.overwriteExisting ?? true })
+  copyDir(templateDir, root, {
+    packageManager,
+    vars,
+    overwriteExisting: options.overwriteExisting ?? true,
+  })
 }
 
 function copyDir(src: string, dest: string, context: CopyContext) {
@@ -74,6 +92,10 @@ function copyDir(src: string, dest: string, context: CopyContext) {
 
 function copyEntry(input: CopyEntryInput, context: CopyContext): void {
   const { src, dest, entry } = input
+  if (context.packageManager !== "pnpm" && entry.name === "pnpm-workspace.yaml") {
+    return
+  }
+
   const srcPath = path.join(src, entry.name)
   // Rename _gitignore -> .gitignore (npm strips .gitignore during pack)
   const destName = entry.name === "_gitignore" ? ".gitignore" : entry.name
@@ -114,6 +136,35 @@ export function formatTargetDir(targetDir: string | undefined) {
   }
 
   return normalized
+}
+
+export function validateTargetDir(targetDir: string | undefined): string | true {
+  const normalized = formatTargetDir(targetDir)
+  if (normalized == null || normalized === "") {
+    return "Project name is required"
+  }
+
+  if (normalized !== "." && /^[.-]/.test(path.basename(normalized))) {
+    return "Project name cannot start with a dot or hyphen"
+  }
+
+  if (normalized.includes("\0")) {
+    return "Project name cannot contain null bytes"
+  }
+
+  return true
+}
+
+export function derivePackageName(targetDir: string, root = path.resolve(targetDir)): string {
+  const baseName = targetDir === "." ? path.basename(root) : path.basename(targetDir)
+  const packageName = baseName
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[\s_]+/g, "-")
+    .replaceAll(/[^a-z0-9-]/g, "")
+    .replaceAll(/^-+/g, "")
+
+  return packageName === "" ? "my-docs" : packageName
 }
 
 export function isEmpty(dirPath: string) {

--- a/packages/create-ardo/templates/minimal/.github/workflows/deploy.yml
+++ b/packages/create-ardo/templates/minimal/.github/workflows/deploy.yml
@@ -21,23 +21,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+{{WORKFLOW_PACKAGE_MANAGER_SETUP}}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '22'
-          cache: 'pnpm'
+{{WORKFLOW_SETUP_NODE_CACHE}}
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: {{WORKFLOW_INSTALL_COMMAND}}
 
       - name: Build
-        run: pnpm build
+        run: {{WORKFLOW_BUILD_COMMAND}}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/packages/create-ardo/templates/minimal/app/routes/guide/getting-started.mdx
+++ b/packages/create-ardo/templates/minimal/app/routes/guide/getting-started.mdx
@@ -2,6 +2,8 @@
 title: Getting Started
 ---
 
+import { ArdoNote } from "ardo/ui"
+
 # Getting Started
 
 Welcome to your new documentation site!
@@ -10,27 +12,32 @@ Welcome to your new documentation site!
 
 ```bash
 # Start development server
-pnpm dev
+{{PACKAGE_MANAGER_DEV}}
 
 # Build for production
-pnpm build
+{{PACKAGE_MANAGER_BUILD}}
 
 # Preview production build
-pnpm preview
+{{PACKAGE_MANAGER_PREVIEW}}
 ```
 
 ## Adding Content
 
 Create `.md` or `.mdx` files in the `app/routes/` directory. They will automatically become pages.
 
+<ArdoNote title="MDX components">
+  You can import React components directly in `.mdx` files and compose them with Markdown.
+</ArdoNote>
+
 ## Configuration
 
-Edit `vite.config.ts` to customize your site:
+Edit `vite.config.ts` for build-time site metadata:
 
-- Navigation links
-- Sidebar structure
 - Site title and description
-- Theme options
+- TypeDoc API pages
+- GitHub Pages deployment settings
+
+Edit `app/root.tsx` to customize UI chrome such as navigation, sidebar items, and theme options.
 
 ## Learn More
 

--- a/packages/create-ardo/templates/minimal/app/routes/home.tsx
+++ b/packages/create-ardo/templates/minimal/app/routes/home.tsx
@@ -1,5 +1,5 @@
 import { ArdoHero, ArdoFeatures, ArdoFeatureCard } from "ardo/ui"
-import { Zap, Sparkles, Palette, ArrowRight, Github } from "ardo/icons"
+import { Zap, Sparkles, Palette, ArrowRight } from "ardo/icons"
 import type { MetaFunction } from "react-router"
 
 export const meta: MetaFunction = () => [
@@ -19,12 +19,6 @@ export default function HomePage() {
             link: "/guide/getting-started",
             theme: "brand",
             icon: <ArrowRight size={16} />,
-          },
-          {
-            text: "GitHub",
-            link: "https://github.com",
-            theme: "alt",
-            icon: <Github size={16} />,
           },
         ]}
       />

--- a/packages/create-ardo/templates/minimal/package.json
+++ b/packages/create-ardo/templates/minimal/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "react-router dev",
     "build": "react-router build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "ardo": "^{{ARDO_VERSION}}",

--- a/packages/create-ardo/templates/minimal/pnpm-workspace.yaml
+++ b/packages/create-ardo/templates/minimal/pnpm-workspace.yaml
@@ -3,6 +3,3 @@ packages:
 
 allowBuilds:
   esbuild: true
-
-onlyBuiltDependencies:
-  - esbuild


### PR DESCRIPTION
## Summary
- add create-ardo argument parsing for --yes, --title, --typedoc/--no-typedoc, and --github-pages/--no-github-pages
- normalize positional target directories and derive a safe package name from the basename
- detect npm/pnpm/yarn/bun from npm_config_user_agent and adapt printed commands, generated workflow commands, and pnpm-only workspace output
- polish the minimal template with a typecheck script, no placeholder GitHub button, clearer generated getting-started guidance, and an MDX component example

## Notes
- The audit item for #231 suggested removing allowBuilds and keeping onlyBuiltDependencies. Current pnpm 11 ignores package.json pnpm.onlyBuiltDependencies and still blocks esbuild when pnpm-workspace.yaml only contains onlyBuiltDependencies. This PR keeps the working allowBuilds setting and removes the redundant onlyBuiltDependencies entry instead; full scaffold integration verifies pnpm install/build still works.

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm lint (0 errors; existing warnings remain)
- pnpm build
- pnpm test
- pnpm docs:build (passes; existing generated API/demo broken-link warnings remain)
- built CLI smoke via packages/create-ardo/dist/index.js with npm user agent: verifies non-interactive target normalization, package name my-docs, npm workflow commands, no pnpm-workspace.yaml, and MDX component demo

Closes #228
Closes #229
Closes #230
Closes #231
Refs #246