### PR TITLE
fix: harden code highlighting and route strings

### DIFF
--- a/packages/ardo/src/markdown/shiki-rehype.ts
+++ b/packages/ardo/src/markdown/shiki-rehype.ts
@@ -9,6 +9,7 @@ import { shikiContainerClassName } from "../ui/components/code-block-classes"
 import { buildCodeBlockHtml } from "./shiki-html"
 import { parseHighlightLines, parseTitle } from "./shiki-meta"
 import { highlightWithTheme, resolveThemeConfig } from "./shiki-theme"
+import { warnHighlightFailure } from "./shiki-warnings"
 
 type RehypeShikiOptions = {
   config: MarkdownConfig
@@ -88,7 +89,8 @@ function tryRenderHighlightedHtml(params: {
       lineNumbers: (context.config.lineNumbers ?? false) || metaString.includes("showLineNumbers"),
       title: parseTitle(metaString),
     })
-  } catch {
+  } catch (error) {
+    warnHighlightFailure({ error, language })
     return null
   }
 }

--- a/packages/ardo/src/markdown/shiki-warnings.ts
+++ b/packages/ardo/src/markdown/shiki-warnings.ts
@@ -1,0 +1,25 @@
+type HighlightWarningInput = {
+  error: unknown
+  language: string
+  sourcePath?: string
+}
+
+const warnedHighlightFailures = new Set<string>()
+
+export function warnHighlightFailure(input: HighlightWarningInput): void {
+  const source = input.sourcePath ?? "<unknown>"
+  const warningKey = `${source}\0${input.language}`
+  if (warnedHighlightFailures.has(warningKey)) {
+    return
+  }
+
+  warnedHighlightFailures.add(warningKey)
+  const sourceText = input.sourcePath == null ? "" : ` in ${input.sourcePath}`
+  console.warn(
+    `[ardo] Could not highlight ${JSON.stringify(input.language)} code${sourceText}: ${formatErrorMessage(input.error)}`
+  )
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/ardo/src/markdown/shiki.test.ts
+++ b/packages/ardo/src/markdown/shiki.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  bundledLanguages: {
+    java: {},
+    javascript: {},
+    php: {},
+  },
+  createHighlighter: vi.fn(),
+}))
+
+vi.mock("shiki", () => ({
+  bundledLanguages: mocks.bundledLanguages,
+  createHighlighter: mocks.createHighlighter,
+}))
+
+describe("shiki highlighter", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.createHighlighter.mockReset()
+    mocks.createHighlighter.mockImplementation(() => ({
+      codeToHtml: vi.fn((_code: string, options: unknown) => JSON.stringify(options)),
+    }))
+  })
+
+  it("loads Shiki's bundled languages instead of a fixed local subset", async () => {
+    const { createShikiHighlighter } = await import("./shiki")
+
+    await createShikiHighlighter({})
+
+    expect(mocks.createHighlighter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        langs: ["java", "javascript", "php"],
+      })
+    )
+  })
+
+  it("caches highlighters by theme configuration", async () => {
+    const { highlightCode } = await import("./shiki")
+
+    await highlightCode("const value = 1", "javascript", { theme: "github-dark-default" })
+    await highlightCode("const value = 2", "javascript", { theme: "github-dark-default" })
+    await highlightCode("const value = 3", "javascript", { theme: "github-light-default" })
+
+    expect(mocks.createHighlighter).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/ardo/src/markdown/shiki.ts
+++ b/packages/ardo/src/markdown/shiki.ts
@@ -1,4 +1,4 @@
-import { createHighlighter, type Highlighter } from "shiki"
+import { type BundledLanguage, bundledLanguages, createHighlighter, type Highlighter } from "shiki"
 
 import type { MarkdownConfig } from "../config/types"
 
@@ -9,7 +9,8 @@ export { ardoLineTransformer, remarkCodeMeta } from "./shiki-transformer"
 
 export type ShikiHighlighter = Highlighter
 
-let cachedHighlighterPromise: Promise<ShikiHighlighter> | undefined
+const allBundledLanguages = Object.keys(bundledLanguages).filter(isBundledLanguage)
+const cachedHighlighterPromises = new Map<string, Promise<ShikiHighlighter>>()
 
 /**
  * Highlights code using Shiki with Ardo's default themes.
@@ -34,14 +35,19 @@ export async function highlightCode(
 async function getCachedHighlighter(
   themeConfig: MarkdownConfig["theme"]
 ): Promise<ShikiHighlighter> {
-  cachedHighlighterPromise ??= createShikiHighlighter({
-    anchor: false,
-    lineNumbers: false,
-    theme: themeConfig,
-    toc: { level: [2, 3] },
-  })
+  const cacheKey = getThemeCacheKey(themeConfig)
+  let highlighterPromise = cachedHighlighterPromises.get(cacheKey)
+  if (highlighterPromise == null) {
+    highlighterPromise = createShikiHighlighter({
+      anchor: false,
+      lineNumbers: false,
+      theme: themeConfig,
+      toc: { level: [2, 3] },
+    })
+    cachedHighlighterPromises.set(cacheKey, highlighterPromise)
+  }
 
-  return cachedHighlighterPromise
+  return highlighterPromise
 }
 
 export async function createShikiHighlighter(config: MarkdownConfig): Promise<ShikiHighlighter> {
@@ -49,39 +55,20 @@ export async function createShikiHighlighter(config: MarkdownConfig): Promise<Sh
 
   return createHighlighter({
     themes: getBundledThemes(themeConfig),
-    langs: [
-      // Web fundamentals
-      "javascript",
-      "typescript",
-      "jsx",
-      "tsx",
-      "html",
-      "css",
-      "scss",
-
-      // Data & config formats
-      "json",
-      "jsonc",
-      "yaml",
-      "toml",
-      "xml",
-      "graphql",
-
-      // Markdown & docs
-      "markdown",
-      "mdx",
-
-      // Shell & DevOps
-      "bash",
-      "shell",
-      "dockerfile",
-
-      // General purpose
-      "python",
-      "rust",
-      "go",
-      "sql",
-      "diff",
-    ],
+    langs: allBundledLanguages,
   })
+}
+
+function getThemeCacheKey(themeConfig: MarkdownConfig["theme"]): string {
+  if (themeConfig == null) {
+    return "default"
+  }
+
+  return typeof themeConfig === "string"
+    ? `theme:${themeConfig}`
+    : `themes:${themeConfig.light}\0${themeConfig.dark}`
+}
+
+function isBundledLanguage(language: string): language is BundledLanguage {
+  return language in bundledLanguages
 }

--- a/packages/ardo/src/vite/codeblock-plugin.ts
+++ b/packages/ardo/src/vite/codeblock-plugin.ts
@@ -20,7 +20,7 @@ export function ardoCodeBlockPlugin(markdownConfig?: MarkdownConfig): Plugin {
         return
       }
 
-      const transformed = await transformArdoCodeBlocks(code, markdownConfig)
+      const transformed = await transformArdoCodeBlocks(code, markdownConfig, { sourcePath: id })
       if (transformed === code) {
         return
       }

--- a/packages/ardo/src/vite/codeblock-transform.test.ts
+++ b/packages/ardo/src/vite/codeblock-transform.test.ts
@@ -20,7 +20,24 @@ describe("transformArdoCodeBlocks", () => {
   beforeEach(() => {
     mocks.highlightCode.mockReset()
     mocks.warnHighlightFailure.mockReset()
-    mocks.highlightCode.mockResolvedValue("<pre>highlighted</pre>")
+    mocks.highlightCode.mockResolvedValue("<pre>$&</pre>")
+  })
+
+  it("does not expand replacement-pattern tokens when injecting highlighted props", async () => {
+    const source = '<ArdoCodeBlock code="console.log(1)" language="tsx" />'
+
+    const result = await transformArdoCodeBlocks(source)
+
+    expect(result).toContain('__html={"<pre>$&</pre>"}')
+    expect(result).not.toContain('{"<pre>code=')
+  })
+
+  it("decodes escaped newlines without corrupting literal backslash-n content", async () => {
+    await transformArdoCodeBlocks(String.raw`<ArdoCodeBlock code="\n" language="tsx" />`)
+    expect(mocks.highlightCode).toHaveBeenLastCalledWith("\n", "tsx", expect.any(Object))
+
+    await transformArdoCodeBlocks(String.raw`<ArdoCodeBlock code="\\n" language="tsx" />`)
+    expect(mocks.highlightCode).toHaveBeenLastCalledWith("\\n", "tsx", expect.any(Object))
   })
 
   it("warns once and leaves the source unchanged when highlighting fails", async () => {

--- a/packages/ardo/src/vite/codeblock-transform.test.ts
+++ b/packages/ardo/src/vite/codeblock-transform.test.ts
@@ -1,0 +1,42 @@
+/* eslint-disable import/first -- vi.mock must be hoisted before importing the transform. */
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  highlightCode: vi.fn(),
+  warnHighlightFailure: vi.fn(),
+}))
+
+vi.mock("../markdown/shiki", () => ({
+  highlightCode: mocks.highlightCode,
+}))
+
+vi.mock("../markdown/shiki-warnings", () => ({
+  warnHighlightFailure: mocks.warnHighlightFailure,
+}))
+
+import { transformArdoCodeBlocks } from "./codeblock-transform"
+
+describe("transformArdoCodeBlocks", () => {
+  beforeEach(() => {
+    mocks.highlightCode.mockReset()
+    mocks.warnHighlightFailure.mockReset()
+    mocks.highlightCode.mockResolvedValue("<pre>highlighted</pre>")
+  })
+
+  it("warns once and leaves the source unchanged when highlighting fails", async () => {
+    const error = new Error("Unsupported language")
+    mocks.highlightCode.mockRejectedValue(error)
+    const source = '<ArdoCodeBlock code="class Demo {}" language="java" />'
+
+    const result = await transformArdoCodeBlocks(source, undefined, {
+      sourcePath: "/docs/demo.tsx",
+    })
+
+    expect(result).toBe(source)
+    expect(mocks.warnHighlightFailure).toHaveBeenCalledWith({
+      error,
+      language: "java",
+      sourcePath: "/docs/demo.tsx",
+    })
+  })
+})

--- a/packages/ardo/src/vite/codeblock-transform.ts
+++ b/packages/ardo/src/vite/codeblock-transform.ts
@@ -1,18 +1,31 @@
 import type { MarkdownConfig } from "../config/types"
 
 import { highlightCode } from "../markdown/shiki"
+import { warnHighlightFailure } from "../markdown/shiki-warnings"
 import { outdent, scanArdoCodeBlocks, type ScannedCodeBlock } from "./codeblock-scan"
+
+type TransformArdoCodeBlocksOptions = {
+  sourcePath?: string
+}
+
+type HighlightCodeRequest = {
+  codeContent: string
+  language: string
+  markdownConfig: MarkdownConfig | undefined
+  options: TransformArdoCodeBlocksOptions
+}
 
 export async function transformArdoCodeBlocks(
   source: string,
-  markdownConfig?: MarkdownConfig
+  markdownConfig?: MarkdownConfig,
+  options: TransformArdoCodeBlocksOptions = {}
 ): Promise<string> {
   let result = source
   let offset = 0
   const blocks = scanArdoCodeBlocks(source)
 
   for (const block of blocks) {
-    const replacement = await createReplacement(block, markdownConfig)
+    const replacement = await createReplacement(block, markdownConfig, options)
     if (replacement == null) {
       continue
     }
@@ -28,22 +41,24 @@ export async function transformArdoCodeBlocks(
 
 async function createReplacement(
   block: ScannedCodeBlock,
-  markdownConfig?: MarkdownConfig
+  markdownConfig: MarkdownConfig | undefined,
+  options: TransformArdoCodeBlocksOptions
 ): Promise<null | string> {
   if (block.props.includes("__html")) {
     return null
   }
 
   if (block.children == null) {
-    return createSelfClosingReplacement(block, markdownConfig)
+    return createSelfClosingReplacement(block, markdownConfig, options)
   }
 
-  return createChildrenReplacement(block, markdownConfig)
+  return createChildrenReplacement(block, markdownConfig, options)
 }
 
 async function createSelfClosingReplacement(
   block: ScannedCodeBlock,
-  markdownConfig?: MarkdownConfig
+  markdownConfig: MarkdownConfig | undefined,
+  options: TransformArdoCodeBlocksOptions
 ): Promise<null | string> {
   const codeValue = extractCodeValue(block.props)
   const language = extractPropValue(block.props, "language")
@@ -51,7 +66,12 @@ async function createSelfClosingReplacement(
     return null
   }
 
-  const html = await safeHighlightCode(codeValue, language, markdownConfig)
+  const html = await safeHighlightCode({
+    codeContent: codeValue,
+    language,
+    markdownConfig,
+    options,
+  })
   if (html == null) {
     return null
   }
@@ -63,7 +83,8 @@ async function createSelfClosingReplacement(
 
 async function createChildrenReplacement(
   block: ScannedCodeBlock,
-  markdownConfig?: MarkdownConfig
+  markdownConfig: MarkdownConfig | undefined,
+  options: TransformArdoCodeBlocksOptions
 ): Promise<null | string> {
   const language = extractPropValue(block.props, "language")
   if (language == null || block.children == null) {
@@ -72,7 +93,12 @@ async function createChildrenReplacement(
 
   const rawChildren = unwrapTemplateChildren(block.children)
   const codeContent = outdent(rawChildren)
-  const html = await safeHighlightCode(codeContent, language, markdownConfig)
+  const html = await safeHighlightCode({
+    codeContent,
+    language,
+    markdownConfig,
+    options,
+  })
   if (html == null) {
     return null
   }
@@ -125,16 +151,14 @@ function getPropPatterns(propName: string): RegExp[] {
   ]
 }
 
-async function safeHighlightCode(
-  codeContent: string,
-  language: string,
-  markdownConfig?: MarkdownConfig
-): Promise<null | string> {
+async function safeHighlightCode(request: HighlightCodeRequest): Promise<null | string> {
+  const { codeContent, language, markdownConfig, options } = request
   try {
     return await highlightCode(codeContent, language, {
       theme: markdownConfig?.theme,
     })
-  } catch {
+  } catch (error) {
+    warnHighlightFailure({ error, language, sourcePath: options.sourcePath })
     return null
   }
 }

--- a/packages/ardo/src/vite/codeblock-transform.ts
+++ b/packages/ardo/src/vite/codeblock-transform.ts
@@ -78,7 +78,7 @@ async function createSelfClosingReplacement(
 
   const escapedHtml = JSON.stringify(html)
   const newProps = `__html={${escapedHtml}} ${block.props}`
-  return block.fullMatch.replace(block.props, newProps)
+  return block.fullMatch.replace(block.props, () => newProps)
 }
 
 async function createChildrenReplacement(
@@ -127,7 +127,18 @@ function extractCodeValue(props: string): null | string {
 }
 
 function decodeEscapedString(value: string): string {
-  return value.replaceAll("\\n", "\n").replaceAll('\\"', '"').replaceAll("\\\\", "\\")
+  return value.replaceAll(/\\(["\\nrt])/gu, (_match, escaped: string) => {
+    switch (escaped) {
+      case "n":
+        return "\n"
+      case "r":
+        return "\r"
+      case "t":
+        return "\t"
+      default:
+        return escaped
+    }
+  })
 }
 
 function extractPropValue(props: string, propName: string): null | string {

--- a/packages/ardo/src/vite/path-utils.ts
+++ b/packages/ardo/src/vite/path-utils.ts
@@ -17,6 +17,10 @@ export function normalizePath(filePath: string): string {
   return filePath.replaceAll("\\", "/")
 }
 
+export function stripPathSuffix(value: string, suffix: string): string {
+  return value.endsWith(suffix) ? value.slice(0, -suffix.length) : value
+}
+
 function trimTrailingSlashes(value: string): string {
   let end = value.length
   while (end > 0 && value[end - 1] === "/") {

--- a/packages/ardo/src/vite/routes-core.test.ts
+++ b/packages/ardo/src/vite/routes-core.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { scanRoutesSync } from "./routes-core"
+
+let routesDir: string
+
+beforeEach(() => {
+  routesDir = fs.mkdtempSync(path.join(os.tmpdir(), "ardo-routes-"))
+})
+
+afterEach(() => {
+  fs.rmSync(routesDir, { force: true, recursive: true })
+})
+
+describe("scanRoutesSync", () => {
+  it("strips only the final route extension from nested paths", () => {
+    writeRoute("v1.md/changelog.md", "# Changelog")
+    writeRoute("guide/changelog.md.mdx", "# Changelog")
+
+    expect(scanRoutesSync({ dir: routesDir, rootDir: routesDir })).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "/v1.md/changelog" }),
+        expect.objectContaining({ path: "/guide/changelog.md" }),
+      ])
+    )
+  })
+})
+
+function writeRoute(relativePath: string, content: string): void {
+  const filePath = path.join(routesDir, relativePath)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, content, "utf8")
+}

--- a/packages/ardo/src/vite/routes-core.ts
+++ b/packages/ardo/src/vite/routes-core.ts
@@ -2,6 +2,8 @@ import fsSync from "node:fs"
 import fs from "node:fs/promises"
 import path from "node:path"
 
+import { stripPathSuffix } from "./path-utils"
+
 export type RouteInfo = {
   /** File path relative to app directory (e.g., "routes/guide/getting-started.mdx") */
   file: string
@@ -57,7 +59,7 @@ function createRouteInfo(params: {
   }
 
   const relativePath = path.relative(rootDir, fullPath)
-  const baseName = entryName.replace(extension, "")
+  const baseName = stripPathSuffix(entryName, extension)
   const urlPath = toRoutePath({
     baseName,
     extension,
@@ -108,7 +110,7 @@ function toRoutePath(params: {
     return applyDynamicSegments(`/${normalizedParent}`)
   }
 
-  const withoutExtension = relativePath.replace(extension, "")
+  const withoutExtension = stripPathSuffix(relativePath, extension)
   return applyDynamicSegments(`/${withoutExtension.replaceAll("\\", "/")}`)
 }
 

--- a/packages/ardo/src/vite/search-index.test.ts
+++ b/packages/ardo/src/vite/search-index.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { generateSearchIndex } from "./search-index"
+
+let routesDir: string
+
+beforeEach(async () => {
+  routesDir = await fs.mkdtemp(path.join(os.tmpdir(), "ardo-search-"))
+})
+
+afterEach(async () => {
+  await fs.rm(routesDir, { force: true, recursive: true })
+})
+
+describe("generateSearchIndex", () => {
+  it("strips only the final markdown extension from route paths", async () => {
+    await writeRoute("v1.md/changelog.md", "# Changelog")
+    await writeRoute("guide/changelog.md.mdx", "# Changelog")
+
+    expect(await generateSearchIndex(routesDir)).toStrictEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "/v1.md/changelog" }),
+        expect.objectContaining({ path: "/guide/changelog.md" }),
+      ])
+    )
+  })
+})
+
+async function writeRoute(relativePath: string, content: string): Promise<void> {
+  const filePath = path.join(routesDir, relativePath)
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  await fs.writeFile(filePath, content, "utf8")
+}

--- a/packages/ardo/src/vite/search-index.ts
+++ b/packages/ardo/src/vite/search-index.ts
@@ -4,6 +4,8 @@ import matter from "gray-matter"
 import fs from "node:fs/promises"
 import path from "node:path"
 
+import { stripPathSuffix } from "./path-utils"
+
 export type SearchDoc = {
   id: string
   title: string
@@ -84,7 +86,7 @@ async function createSearchDocFromFile(
   const title =
     typeof parsed.data.title === "string"
       ? parsed.data.title
-      : formatTitle(fileName.replace(extension, ""))
+      : formatTitle(stripPathSuffix(fileName, extension))
 
   const relativePath = path.relative(context.routesDir, filePath)
   const routePath = buildRoutePath(relativePath, fileName, extension)
@@ -176,7 +178,7 @@ function buildRoutePath(relativePath: string, fileName: string, extension: strin
     return directoryPath === "." ? "/" : `/${directoryPath}`
   }
 
-  return `/${relativePath.replace(extension, "").replaceAll("\\", "/")}`
+  return `/${stripPathSuffix(relativePath, extension).replaceAll("\\", "/")}`
 }
 
 function createNestedSection(section: string | undefined, directoryName: string): string {

--- a/packages/ardo/src/vite/sidebar-index.test.ts
+++ b/packages/ardo/src/vite/sidebar-index.test.ts
@@ -239,6 +239,22 @@ sidebar: leaf
       },
     ])
   })
+
+  it("strips only the final markdown extension from generated links", async () => {
+    await writeRoute("v1.md/changelog.md", "---\ntitle: Changelog\n---\n")
+    await writeRoute("guide/changelog.md.mdx", "---\ntitle: Changelog MDX\n---\n")
+
+    expect(toVirtualSidebar(await generateSidebar(routesDir))).toStrictEqual([
+      {
+        text: "Guide",
+        items: [{ text: "Changelog MDX", link: "/guide/changelog.md" }],
+      },
+      {
+        text: "V1.Md",
+        items: [{ text: "Changelog", link: "/v1.md/changelog" }],
+      },
+    ])
+  })
 })
 
 async function writeRoute(relativePath: string, content: string): Promise<void> {

--- a/packages/ardo/src/vite/sidebar-index.ts
+++ b/packages/ardo/src/vite/sidebar-index.ts
@@ -6,6 +6,8 @@ import path from "node:path"
 
 import type { SidebarConfig, SidebarItem } from "../config/types"
 
+import { stripPathSuffix } from "./path-utils"
+
 type SidebarNode = {
   text: string
   link?: string
@@ -161,14 +163,14 @@ async function createMarkdownNode(
     return null
   }
 
-  const title = frontmatter.title ?? formatTitle(entry.name.replace(extension, ""))
-  const link = `/${relativePath.replace(extension, "").replaceAll("\\", "/")}`
+  const title = frontmatter.title ?? formatTitle(stripPathSuffix(entry.name, extension))
+  const link = `/${stripPathSuffix(relativePath, extension).replaceAll("\\", "/")}`
 
   return {
     text: title,
     link,
     order: frontmatter.order,
-    sectionId: entry.name.replace(extension, ""),
+    sectionId: stripPathSuffix(entry.name, extension),
   }
 }
 


### PR DESCRIPTION
## Summary

- load Shiki's bundled language set, key highlighter caching by theme config, and emit one-time warnings for highlighting failures
- preserve literal code strings when pre-highlighting `ArdoCodeBlock` props, including replacement tokens and escaped backslashes
- strip only final route file suffixes for route generation, sidebar links, and search paths

## Issues

Refs #246
Closes #214
Closes #215

## Validation

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm exec vitest run packages/ardo/src/markdown/shiki.test.ts packages/ardo/src/vite/codeblock-transform.test.ts packages/ardo/src/vite/routes-core.test.ts packages/ardo/src/vite/sidebar-index.test.ts packages/ardo/src/vite/search-index.test.ts`
- `pnpm lint` (passes with existing warnings)
- `pnpm build`
- `pnpm test`
- `pnpm docs:build` (passes with existing generated API/demo broken-link warnings)
