### PR TITLE
fix: harden UI shell CSS and mobile chrome

### DIFF
--- a/docs/app/routes/guide/custom-theme.mdx
+++ b/docs/app/routes/guide/custom-theme.mdx
@@ -171,6 +171,23 @@ globalStyle(".ardo-content a", {
 })
 ```
 
+### Stable override hooks
+
+Ardo's generated Vanilla Extract class names are implementation details. Use the stable hook classes
+for narrowly scoped overrides:
+
+| Class                | Landmark                      |
+| -------------------- | ----------------------------- |
+| `.ardo-header`       | Default header shell          |
+| `.ardo-nav`          | Default navigation container  |
+| `.ardo-mobile-panel` | Mobile navigation dialog      |
+| `.ardo-sidebar`      | Sidebar shell                 |
+| `.ardo-footer`       | Default footer shell          |
+| `.ardo-content`      | Rendered Markdown/MDX content |
+
+These classes are override anchors, not a replacement styling API. Prefer tokens and component props
+first, then use the hooks for project-specific adjustments that need a stable selector.
+
 ### Available token categories
 
 The `vars` object provides tokens for:

--- a/docs/app/routes/guide/site-ui.mdx
+++ b/docs/app/routes/guide/site-ui.mdx
@@ -95,7 +95,17 @@ export default function Root() {
 | `mobileMenuContent` | Additional content for the mobile menu. `ArdoRoot` supplies the sidebar. |
 | `className`         | Replace the default header class.                                        |
 
-Pass `header` instead of `headerProps` when your design needs a fully custom header element.
+Pass `header` instead of `headerProps` when your design needs a fully custom header element. Pass
+`header={null}` when a root layout should intentionally render no header.
+
+For route-level chrome suppression, export a `handle` from the route:
+
+```tsx title="app/routes/landing.tsx"
+export const handle = { layout: "bare", chrome: false }
+```
+
+`chrome: false` removes the default header and footer for that route. `layout: "bare"` still controls
+sidebar and rail rendering.
 
 ## Footer
 
@@ -135,6 +145,8 @@ export default function Root() {
 | `ardoLink`             | Set to `false` to hide the "Built with Ardo" link.                      |
 | `children`             | Full custom footer content. Skips automatic footer rendering.           |
 | `className`            | Replace the default footer class.                                       |
+
+Pass `footer={null}` when a root layout should intentionally render no footer.
 
 ## Edit Links and Last Updated
 

--- a/docs/app/routes/guide/tailwind.mdx
+++ b/docs/app/routes/guide/tailwind.mdx
@@ -116,3 +116,7 @@ If you're building a heavily custom site where you control all styling, you can 
 @import "tailwindcss/preflight.css" layer(base);
 @import "tailwindcss/utilities.css" layer(utilities);
 ```
+
+Ardo's content styles set list markers, table borders, code styles, and spacing explicitly, so
+Markdown content stays readable even when a host reset clears browser defaults. Utility classes still
+win where you apply them in your own components.

--- a/packages/ardo/src/ui/ArdoRoot.tsx
+++ b/packages/ardo/src/ui/ArdoRoot.tsx
@@ -104,7 +104,7 @@ function resolveRootHeader(
   headerProps: ArdoHeaderProps | undefined,
   mobileMenuContent: ReactNode
 ): ReactNode {
-  if (header != null) {
+  if (header !== undefined) {
     return enhanceHeaderWithMobileMenuContent(header, mobileMenuContent)
   }
   return (
@@ -127,6 +127,13 @@ function readLayoutHandle(handle: unknown): string | undefined {
   return typeof layout === "string" ? layout : undefined
 }
 
+function readChromeHandle(handle: unknown): boolean | undefined {
+  if (typeof handle !== "object" || handle === null) return undefined
+  if (!("chrome" in handle)) return undefined
+  const { chrome } = handle
+  return typeof chrome === "boolean" ? chrome : undefined
+}
+
 /**
  * Reads the React Router `handle` exports from every active route match and
  * returns the most specific `layout` value (the deepest match wins). MDX
@@ -138,6 +145,15 @@ function useRouteLayout(): string | undefined {
   for (let i = matches.length - 1; i >= 0; i--) {
     const layout = readLayoutHandle(matches[i].handle)
     if (layout !== undefined) return layout
+  }
+  return undefined
+}
+
+function useRouteChrome(): boolean | undefined {
+  const matches = useMatches()
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const chrome = readChromeHandle(matches[i].handle)
+    if (chrome !== undefined) return chrome
   }
   return undefined
 }
@@ -186,6 +202,8 @@ export function ArdoRoot({
 }: ArdoRootProps) {
   const location = useLocation()
   const layout = useRouteLayout()
+  const routeChrome = useRouteChrome()
+  const showChrome = routeChrome !== false
   // Bare layout: no sidebar, no rail — used for the home page and any other
   // marketing-style routes (TSX or MDX). Falls back to the legacy hardcoded
   // home detection if a route hasn't opted in via `handle.layout`.
@@ -200,11 +218,16 @@ export function ArdoRoot({
   )
   // Search lives in the header now. The sidebar no longer carries it.
   const resolvedSidebar = isBareLayout ? undefined : resolveSidebar(sidebarContent, sidebarProps)
-  const resolvedHeader = resolveRootHeader(
-    header,
-    headerProps,
-    isBareLayout ? undefined : resolvedSidebar
-  )
+  const resolvedHeader = showChrome
+    ? resolveRootHeader(header, headerProps, isBareLayout ? undefined : resolvedSidebar)
+    : null
+  const resolvedFooter = showChrome ? (
+    footer === undefined ? (
+      <ArdoFooter {...footerProps} />
+    ) : (
+      footer
+    )
+  ) : null
 
   const siteConfig = useMemo<ArdoSiteConfig>(
     () => ({ editLink, lastUpdated, tocLabel }),
@@ -222,7 +245,7 @@ export function ArdoRoot({
         className={resolveLayoutClassName(className, isBareLayout)}
         header={resolvedHeader}
         sidebar={resolvedSidebar}
-        footer={footer ?? <ArdoFooter {...footerProps} />}
+        footer={resolvedFooter}
       >
         {children ?? <Outlet />}
       </ArdoLayout>

--- a/packages/ardo/src/ui/Footer.tsx
+++ b/packages/ardo/src/ui/Footer.tsx
@@ -3,6 +3,7 @@ import React, { type ReactNode } from "react"
 import type { ProjectMeta, SponsorConfig } from "../config/types"
 
 import { useArdoConfig } from "../runtime/hooks"
+import { joinClassNames } from "./classnames"
 import * as styles from "./Footer.css"
 import { ArdoOwlMark } from "./OwlMark"
 
@@ -208,14 +209,14 @@ export function ArdoFooter({
 
   if (children != null) {
     return (
-      <footer className={className ?? styles.footer}>
+      <footer className={joinClassNames("ardo-footer", className ?? styles.footer)}>
         <div className={styles.footerContainer}>{children}</div>
       </footer>
     )
   }
 
   return (
-    <footer className={className ?? styles.footer}>
+    <footer className={joinClassNames("ardo-footer", className ?? styles.footer)}>
       <div className={styles.footerContainer}>
         <FooterPrimaryLine
           project={project}

--- a/packages/ardo/src/ui/Header.tsx
+++ b/packages/ardo/src/ui/Header.tsx
@@ -2,6 +2,7 @@ import { type ReactNode, useCallback, useEffect, useRef, useState } from "react"
 import { Link, useLocation } from "react-router"
 
 import { useArdoConfig } from "../runtime/hooks"
+import { joinClassNames } from "./classnames"
 import { ArdoHeaderSearch } from "./components/HeaderSearch"
 import { ArdoThemeToggle } from "./components/ThemeToggle"
 import * as styles from "./Header.css"
@@ -82,14 +83,14 @@ export function ArdoHeader({
   const resolvedTitle = title ?? config.title
   const hasLogo = resolvedLogo !== undefined
   const hasTitle = resolvedTitle !== ""
-  const hasMobileMenu = mobileMenuContent != null
+  const hasMobileMenu = mobileMenuContent != null || nav != null
   const closeMobileMenu = useCallback(() => {
     setMobileMenuOpen(false)
   }, [setMobileMenuOpen])
 
   return (
     <>
-      <header className={className ?? styles.header}>
+      <header className={joinClassNames("ardo-header", className ?? styles.header)}>
         <div className={styles.headerContainer}>
           <div className={styles.headerLeft}>
             {hasMobileMenu && (

--- a/packages/ardo/src/ui/HomePage.tsx
+++ b/packages/ardo/src/ui/HomePage.tsx
@@ -95,12 +95,12 @@ export function ArdoHomePage({ headerProps, footerProps, header, footer }: ArdoH
 
   return (
     <div className={layoutStyles.home}>
-      {header ?? <ArdoHeader title={config.title} {...headerProps} />}
+      {header === undefined ? <ArdoHeader title={config.title} {...headerProps} /> : header}
       <main className={layoutStyles.homeMain}>
         <HomeHeroSection hero={pageData?.frontmatter.hero} fallbackTitle={config.title} />
         <HomeFeaturesSection features={pageData?.frontmatter.features} />
       </main>
-      {footer ?? <ArdoFooter {...footerProps} />}
+      {footer === undefined ? <ArdoFooter {...footerProps} /> : footer}
     </div>
   )
 }

--- a/packages/ardo/src/ui/MobileSlidePanel.tsx
+++ b/packages/ardo/src/ui/MobileSlidePanel.tsx
@@ -1,6 +1,7 @@
 import { type MouseEvent, type ReactNode, type RefObject, useEffect, useRef } from "react"
 import { Link } from "react-router"
 
+import { joinClassNames } from "./classnames"
 import { ArdoThemeToggle } from "./components/ThemeToggle"
 import * as styles from "./Header.css"
 import { XIcon } from "./icons"
@@ -43,7 +44,7 @@ export function MobileSlidePanel({
 
       <div
         ref={panelRef}
-        className={styles.mobilePanel}
+        className={joinClassNames("ardo-mobile-panel", styles.mobilePanel)}
         data-open="true"
         role="dialog"
         aria-modal="true"

--- a/packages/ardo/src/ui/Nav.tsx
+++ b/packages/ardo/src/ui/Nav.tsx
@@ -1,6 +1,7 @@
 import { type ComponentProps, createContext, type ReactNode, use, useMemo, useState } from "react"
 import { NavLink as RouterNavLink } from "react-router"
 
+import { joinClassNames } from "./classnames"
 import * as styles from "./Nav.css"
 
 /** Route path type - uses React Router's NavLink 'to' prop type for type-safe routes */
@@ -40,7 +41,7 @@ export type ArdoNavProps = {
  * ```
  */
 export function ArdoNav({ children, className }: ArdoNavProps) {
-  return <nav className={className ?? styles.nav}>{children}</nav>
+  return <nav className={joinClassNames("ardo-nav", className ?? styles.nav)}>{children}</nav>
 }
 
 // =============================================================================

--- a/packages/ardo/src/ui/Sidebar.tsx
+++ b/packages/ardo/src/ui/Sidebar.tsx
@@ -15,6 +15,7 @@ import { NavLink, useLocation } from "react-router"
 import type { SidebarItem as SidebarItemType } from "../config/types"
 
 import { useArdoContexts, useArdoSidebar } from "../runtime/hooks"
+import { joinClassNames } from "./classnames"
 import { ChevronDownIcon } from "./icons"
 import * as styles from "./Sidebar.css"
 import {
@@ -111,7 +112,7 @@ export function ArdoSidebar({ items, children, header, className }: ArdoSidebarP
 
   return (
     <SidebarContext value={contextValue}>
-      <aside className={className ?? styles.sidebar}>
+      <aside className={joinClassNames("ardo-sidebar", className ?? styles.sidebar)}>
         <SidebarRail items={railItems} />
         <div className={styles.sidebarPanel}>
           {header != null && <div className={styles.sidebarHeader}>{header}</div>}

--- a/packages/ardo/src/ui/classnames.ts
+++ b/packages/ardo/src/ui/classnames.ts
@@ -1,0 +1,5 @@
+export function joinClassNames(...classNames: Array<false | null | string | undefined>): string {
+  return classNames
+    .filter((className): className is string => className != null && className !== "")
+    .join(" ")
+}

--- a/packages/ardo/src/ui/content.css.ts
+++ b/packages/ardo/src/ui/content.css.ts
@@ -76,11 +76,32 @@ globalStyle(`${c} a:hover`, {
   textDecorationColor: vars.color.brand,
 })
 
-globalStyle(`${c} ul, ${c} ol`, {
+globalStyle(`${c} ul`, {
+  listStyle: "disc",
   marginBottom: vars.space.lg,
   paddingLeft: vars.space.lg,
   maxWidth: vars.layout.contentMaxWidth,
   textWrap: "pretty",
+})
+
+globalStyle(`${c} ol`, {
+  listStyle: "decimal",
+  marginBottom: vars.space.lg,
+  paddingLeft: vars.space.lg,
+  maxWidth: vars.layout.contentMaxWidth,
+  textWrap: "pretty",
+})
+
+globalStyle(`${c} ul ul, ${c} ol ul`, {
+  listStyle: "circle",
+})
+
+globalStyle(`${c} ul ul ul, ${c} ol ul ul`, {
+  listStyle: "square",
+})
+
+globalStyle(`${c} ul ol, ${c} ol ol`, {
+  listStyle: "lower-alpha",
 })
 
 globalStyle(`${c} li`, {

--- a/packages/ardo/src/ui/shell.test.tsx
+++ b/packages/ardo/src/ui/shell.test.tsx
@@ -1,0 +1,98 @@
+import type { ReactNode, RefObject } from "react"
+
+import { renderToStaticMarkup } from "react-dom/server"
+import { createMemoryRouter, MemoryRouter, RouterProvider } from "react-router"
+import { describe, expect, it, vi } from "vitest"
+
+import { ArdoProvider } from "../runtime/hooks"
+import { ArdoRoot } from "./ArdoRoot"
+import { ArdoFooter } from "./Footer"
+import { ArdoHeader } from "./Header"
+import { MobileSlidePanel } from "./MobileSlidePanel"
+import { ArdoNav, ArdoNavLink } from "./Nav"
+import { ArdoSidebar } from "./Sidebar"
+
+vi.mock("virtual:ardo/search-index", () => ({ default: [] }))
+
+const config = { title: "Docs" }
+const triggerRef: RefObject<HTMLButtonElement | null> = { current: null }
+const closeMobilePanel = vi.fn<() => void>()
+
+function renderShell(children: ReactNode): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <ArdoProvider config={config} sidebar={[]}>
+        {children}
+      </ArdoProvider>
+    </MemoryRouter>
+  )
+}
+
+function renderRootRoute(element: ReactNode, handle?: unknown): string {
+  const router = createMemoryRouter([{ path: "/", element, handle }], { initialEntries: ["/"] })
+  return renderToStaticMarkup(<RouterProvider router={router} />)
+}
+
+describe("UI shell landmarks", () => {
+  it("keeps stable hook classes on default landmarks", () => {
+    const view = renderShell(
+      <>
+        <ArdoHeader />
+        <ArdoNav>
+          <ArdoNavLink to="/guide">Guide</ArdoNavLink>
+        </ArdoNav>
+        <ArdoSidebar />
+        <MobileSlidePanel title="Docs" triggerRef={triggerRef} onClose={closeMobilePanel}>
+          <span>Panel</span>
+        </MobileSlidePanel>
+        <ArdoFooter />
+      </>
+    )
+
+    expect(view).toContain("ardo-header")
+    expect(view).toContain("ardo-nav")
+    expect(view).toContain("ardo-sidebar")
+    expect(view).toContain("ardo-mobile-panel")
+    expect(view).toContain("ardo-footer")
+  })
+
+  it("renders the mobile menu trigger when only nav is provided", () => {
+    const view = renderShell(
+      <ArdoHeader
+        nav={
+          <ArdoNav>
+            <ArdoNavLink to="/guide">Guide</ArdoNavLink>
+          </ArdoNav>
+        }
+      />
+    )
+
+    expect(view).toContain('aria-label="Toggle menu"')
+    expect(view).toContain('aria-expanded="false"')
+  })
+
+  it("honors explicit null header and footer overrides", () => {
+    const view = renderRootRoute(
+      <ArdoRoot config={config} sidebar={[]} header={null} footer={null}>
+        <p>Content</p>
+      </ArdoRoot>
+    )
+
+    expect(view).toContain("Content")
+    expect(view).not.toContain("ardo-header")
+    expect(view).not.toContain("ardo-footer")
+  })
+
+  it("suppresses route chrome from the route handle", () => {
+    const view = renderRootRoute(
+      <ArdoRoot config={config} sidebar={[]}>
+        <p>Landing</p>
+      </ArdoRoot>,
+      { chrome: false, layout: "bare" }
+    )
+
+    expect(view).toContain("Landing")
+    expect(view).not.toContain("ardo-header")
+    expect(view).not.toContain("ardo-footer")
+  })
+})

--- a/packages/ardo/src/ui/theme/reset.css.ts
+++ b/packages/ardo/src/ui/theme/reset.css.ts
@@ -2,10 +2,8 @@ import { globalStyle } from "@vanilla-extract/css"
 
 import { vars } from "./contract.css"
 
-globalStyle("*", {
+globalStyle("*, *::before, *::after", {
   boxSizing: "border-box",
-  margin: 0,
-  padding: 0,
 })
 
 globalStyle("html", {


### PR DESCRIPTION
## Summary

- stop the global UI reset from clearing consumer margin/padding utilities while keeping safe box sizing
- make Markdown content lists self-sufficient when consumer resets remove browser list defaults
- keep mobile navigation reachable on bare routes with nav-only headers
- support explicit `header={null}` / `footer={null}` and route-level `handle.chrome = false`
- add stable landmark hook classes for common shell override anchors

## Issues

Refs #246
Closes #254
Closes #255
Closes #256
Closes #260
Closes #261

## Validation

- `pnpm format:check`
- `pnpm exec vitest --run packages/ardo/src/ui/shell.test.tsx`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm build`
- `pnpm test`
- `pnpm docs:build` (passes with existing generated API/demo broken-link warnings)
