### PR TITLE
Add theme policy and token override APIs

### DIFF
--- a/docs/app/routes/guide/custom-theme.mdx
+++ b/docs/app/routes/guide/custom-theme.mdx
@@ -65,6 +65,41 @@ The default hue is `356` (a muted berry tone). Some starting points:
 
 For full control over individual tokens, use `createTheme()` instead — it returns the complete `{ light, dark }` token sets for a given hue set, which you can modify before passing to `createGlobalTheme`.
 
+You can also pass token overrides directly. Shared overrides apply to both light and dark themes;
+`light` and `dark` override one mode only:
+
+```ts
+import { applyBrandTheme } from "ardo/theme"
+
+applyBrandTheme({
+  color: {
+    bg: "#fbfbf8",
+    text: "#101010",
+    brand: "#0038ff",
+    brandGradient: "#0038ff",
+    shadowSm: "0 0 0 0 transparent",
+    shadowMd: "0 0 0 0 transparent",
+    shadowLg: "0 0 0 0 transparent",
+  },
+  radius: {
+    sm: "0px",
+    base: "0px",
+    lg: "0px",
+  },
+  dark: {
+    color: {
+      bg: "#101010",
+      text: "#fbfbf8",
+    },
+  },
+})
+```
+
+`shadowSm`, `shadowMd`, `shadowLg`, and `codeShadow` are full `box-shadow` values. Use
+`0 0 0 0 transparent` when a brand wants no shadow; `none` can invalidate declarations that combine
+multiple shadow layers. `brandGradient` also accepts a plain color when gradients are not part of
+your design system.
+
 ## CSS Variables
 
 The fastest way to make the theme yours. Override a few CSS custom properties and the entire site updates:
@@ -90,6 +125,10 @@ Import it in your app:
 import "ardo/ui/styles.css"
 import "./styles/custom.css"
 ```
+
+The `--ardo-*` variables are public override anchors. Ardo ships defaults on `:root` and dark-mode
+values on `.dark`; app CSS can override either selector and those raw variable overrides remain
+supported even when the higher-level theme helpers evolve.
 
 ### Available Variables
 

--- a/docs/app/routes/guide/frontmatter.mdx
+++ b/docs/app/routes/guide/frontmatter.mdx
@@ -46,6 +46,24 @@ description: Learn how to get started with Ardo
 ---
 ```
 
+Ardo also renders `description` as the visible lede under the page title. If the first body
+paragraph has the same normalized text, Ardo skips the lede to avoid showing the sentence twice.
+
+### lede
+
+- Type: `boolean`
+- Default: `true`
+
+Set `lede: false` when `description` should be metadata-only.
+
+```yaml
+---
+title: Getting Started
+description: Learn how to get started with Ardo
+lede: false
+---
+```
+
 ### Social metadata
 
 Markdown routes without their own `meta` export get generated browser, canonical, Open Graph, and Twitter metadata from frontmatter and site config.

--- a/docs/app/routes/guide/site-ui.mdx
+++ b/docs/app/routes/guide/site-ui.mdx
@@ -33,6 +33,28 @@ export default function Root() {
 `ArdoRootLayout` owns the document-level theme bootstrap and global shell setup. `ArdoRoot` owns the
 React Router outlet, Ardo providers, default header, sidebar, and footer.
 
+## RootLayout Theme Policy
+
+By default, `ArdoRootLayout` uses `theme="auto"`: it applies a stored `ardo-theme` preference first
+and falls back to `prefers-color-scheme`. Set an explicit theme policy when a site should not be
+user-selectable:
+
+```tsx
+export function Layout({ children }: { children: React.ReactNode }) {
+  return <ArdoRootLayout theme="light">{children}</ArdoRootLayout>
+}
+```
+
+| Theme policy | Behavior                                                                 |
+| ------------ | ------------------------------------------------------------------------ |
+| `auto`       | Stored user preference wins; system preference is the fallback. Default. |
+| `light`      | Always render light mode and clear stale stored theme preferences.       |
+| `dark`       | Always render dark mode and clear stale stored theme preferences.        |
+| `system`     | Always follow `prefers-color-scheme` and clear stale stored preferences. |
+
+Explicit policies are applied by the inline bootstrap script before first paint, so returning dark
+mode visitors do not see a light-mode flash.
+
 ## ArdoRoot Props
 
 | Prop             | Type                                                                               | Purpose                                                                        |

--- a/packages/ardo/src/config/types.ts
+++ b/packages/ardo/src/config/types.ts
@@ -299,6 +299,8 @@ export type PageFrontmatter = {
   editLink?: boolean
   lastUpdated?: boolean
   sitemap?: boolean
+  /** Set to false to use description only as metadata, not as visible page lede. */
+  lede?: boolean
   llms?: boolean
   redirectFrom?: string | string[]
   prev?: { text: string; link: string } | false | string

--- a/packages/ardo/src/typedoc/generator-pages-index.ts
+++ b/packages/ardo/src/typedoc/generator-pages-index.ts
@@ -19,7 +19,12 @@ export function generateIndexPage(
   context: TypeDocRuntimeContext,
   grouped: GroupedReflections
 ): GeneratedApiDoc {
-  const lines: string[] = [`# ${context.config.sidebar.title}`, "", getProjectSummary(context), ""]
+  const lines: string[] = [`# ${context.config.sidebar.title}`, ""]
+  const projectSummary = getProjectSummary(context)
+  if (projectSummary !== "") {
+    lines.push(projectSummary)
+    lines.push("")
+  }
 
   appendComponentSection(lines, context, grouped.componentItems)
   appendFunctionsSection(lines, context, grouped.functionsByFile)
@@ -40,7 +45,7 @@ export function generateIndexPage(
 function getProjectSummary(context: TypeDocRuntimeContext): string {
   const summary = context.project.comment?.summary
   if (summary == null) {
-    return "Auto-generated API documentation."
+    return ""
   }
   return renderComment(summary)
 }

--- a/packages/ardo/src/ui/Content.test.tsx
+++ b/packages/ardo/src/ui/Content.test.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react"
+
+import { renderToStaticMarkup } from "react-dom/server"
+import { MemoryRouter } from "react-router"
+import { describe, expect, it } from "vitest"
+
+import type { PageData } from "../config/types"
+
+import { ArdoProvider } from "../runtime/hooks"
+import { ArdoContent } from "./Content"
+
+function renderContent(pageData: PageData, children: ReactNode): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <ArdoProvider config={{ title: "Docs" }} currentPage={pageData} sidebar={[]}>
+        <ArdoContent>{children}</ArdoContent>
+      </ArdoProvider>
+    </MemoryRouter>
+  )
+}
+
+function createPageData(frontmatter: PageData["frontmatter"]): PageData {
+  return {
+    content: "",
+    filePath: "",
+    frontmatter,
+    relativePath: "guide/page.mdx",
+    title: frontmatter.title ?? "",
+    toc: [],
+  }
+}
+
+describe("ArdoContent", () => {
+  it("does not render duplicate lede text when the first paragraph matches description", () => {
+    const view = renderContent(
+      createPageData({
+        description: "Same introduction text.",
+        title: "Guide",
+      }),
+      <p>Same introduction text.</p>
+    )
+
+    expect(view.match(/Same introduction text\./g)).toHaveLength(1)
+  })
+
+  it("can keep description metadata out of visible content explicitly", () => {
+    const view = renderContent(
+      createPageData({
+        description: "Metadata-only description.",
+        lede: false,
+        title: "Guide",
+      }),
+      <p>Different body text.</p>
+    )
+
+    expect(view).not.toContain("Metadata-only description.")
+    expect(view).toContain("Different body text.")
+  })
+
+  it("renders the lede when the first paragraph is different", () => {
+    const view = renderContent(
+      createPageData({
+        description: "Short page summary.",
+        title: "Guide",
+      }),
+      <p>First body paragraph.</p>
+    )
+
+    expect(view).toContain("Short page summary.")
+    expect(view).toContain("First body paragraph.")
+  })
+})

--- a/packages/ardo/src/ui/Content.tsx
+++ b/packages/ardo/src/ui/Content.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from "react"
-
+import { Children, Fragment, isValidElement, type ReactNode } from "react"
 import { Link, useLocation } from "react-router"
 
 import { useArdoPageData, useArdoSidebar, useArdoSiteConfig } from "../runtime/hooks"
@@ -86,6 +85,11 @@ export function ArdoContent({
       <ContentHeader
         title={pageData?.frontmatter.title ?? ""}
         description={pageData?.frontmatter.description ?? ""}
+        showDescription={shouldShowDescription(
+          pageData?.frontmatter.description ?? "",
+          pageData?.frontmatter.lede,
+          children
+        )}
       />
       <div className={`${docStyles.contentBody} ${ardoContent}`}>{children}</div>
       {metaPlacement === "footer" && <ContentMeta edit={edit} updated={updated} />}
@@ -94,14 +98,84 @@ export function ArdoContent({
   )
 }
 
-function ContentHeader({ title, description }: { title: string; description: string }) {
+function ContentHeader({
+  description,
+  showDescription,
+  title,
+}: {
+  description: string
+  showDescription: boolean
+  title: string
+}) {
   if (title === "") return null
   return (
     <header className={docStyles.contentHeader}>
       <h1 className={docStyles.contentTitle}>{title}</h1>
-      {description !== "" && <p className={docStyles.contentDescription}>{description}</p>}
+      {showDescription && <p className={docStyles.contentDescription}>{description}</p>}
     </header>
   )
+}
+
+function shouldShowDescription(description: string, lede: unknown, children: ReactNode): boolean {
+  if (description === "" || lede === false) return false
+
+  const firstParagraphText = getFirstParagraphText(children)
+  if (firstParagraphText == null) return true
+
+  return normalizeText(firstParagraphText) !== normalizeText(description)
+}
+
+function getFirstParagraphText(children: ReactNode): string | undefined {
+  for (const child of Children.toArray(children)) {
+    const result = readFirstParagraphCandidate(child)
+    if (result.action === "continue") {
+      continue
+    }
+    return result.text
+  }
+
+  return undefined
+}
+
+type ParagraphCandidate = { action: "continue" } | { action: "return"; text: string | undefined }
+
+function readFirstParagraphCandidate(child: ReactNode): ParagraphCandidate {
+  if (!isValidElement<{ children?: ReactNode }>(child)) {
+    return typeof child === "string" && child.trim() === ""
+      ? { action: "continue" }
+      : { action: "return", text: undefined }
+  }
+
+  if (child.type === Fragment) {
+    const nested = getFirstParagraphText(child.props.children)
+    return nested == null ? { action: "continue" } : { action: "return", text: nested }
+  }
+
+  if (child.type !== "p") {
+    return { action: "return", text: undefined }
+  }
+
+  return { action: "return", text: getNodeText(child.props.children) }
+}
+
+function getNodeText(children: ReactNode): string {
+  return Children.toArray(children)
+    .map((child) => {
+      if (typeof child === "string" || typeof child === "number") {
+        return String(child)
+      }
+
+      if (isValidElement<{ children?: ReactNode }>(child)) {
+        return getNodeText(child.props.children)
+      }
+
+      return ""
+    })
+    .join("")
+}
+
+function normalizeText(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim()
 }
 
 function ContentMeta({

--- a/packages/ardo/src/ui/Layout.tsx
+++ b/packages/ardo/src/ui/Layout.tsx
@@ -4,7 +4,7 @@ import { Links, Meta, Scripts, ScrollRestoration } from "react-router"
 import { ArdoContext } from "../runtime/hooks"
 import { ARDO_FAVICON_DATA_URL } from "./favicon"
 import * as styles from "./Layout.css"
-import { ARDO_THEME_BOOTSTRAP_SCRIPT } from "./theme-mode"
+import { type ArdoThemePreference, getArdoThemeBootstrapScript } from "./theme-mode"
 
 // =============================================================================
 // RootLayout Component (html/head/body shell)
@@ -21,6 +21,16 @@ export type ArdoRootLayoutProps = {
   iconBasePath?: false | string
   /** Language attribute for <html> (default: from config or "en") */
   lang?: string
+  /**
+   * Theme policy applied before first paint.
+   *
+   * - `"auto"` keeps the user-selectable mode: stored `ardo-theme` first,
+   *   then system preference. This is the default.
+   * - `"light"` / `"dark"` force one mode and clear stale stored preferences.
+   * - `"system"` always follows `prefers-color-scheme` and clears stale stored
+   *   preferences.
+   */
+  theme?: ArdoThemePreference
 }
 
 /**
@@ -44,6 +54,7 @@ export function ArdoRootLayout({
   favicon,
   iconBasePath = "/",
   lang,
+  theme = "auto",
 }: ArdoRootLayoutProps) {
   // Use optional context (RootLayout renders before ArdoProvider is available)
   const context = use(ArdoContext)
@@ -55,7 +66,7 @@ export function ArdoRootLayout({
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script dangerouslySetInnerHTML={{ __html: ARDO_THEME_BOOTSTRAP_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: getArdoThemeBootstrapScript(theme) }} />
         {iconBaseUrl == null ? (
           <link rel="icon" type="image/svg+xml" href={favicon ?? ARDO_FAVICON_DATA_URL} />
         ) : (

--- a/packages/ardo/src/ui/components/ThemeToggle.tsx
+++ b/packages/ardo/src/ui/components/ThemeToggle.tsx
@@ -4,6 +4,7 @@ import { MonitorIcon, MoonIcon, SunIcon } from "../icons"
 import {
   applyThemeMode,
   type ArdoThemeMode,
+  getConfiguredThemeMode,
   getInitialThemeMode,
   storeThemeMode,
   subscribeSystemThemeChanges,
@@ -13,14 +14,20 @@ import * as styles from "./ThemeToggle.css"
 export function ArdoThemeToggle() {
   const [theme, setTheme] = useState<ArdoThemeMode>(getInitialThemeMode)
   const mounted = useSyncExternalStore(subscribeMounted, getClientMounted, getServerMounted)
+  const configuredTheme = mounted ? getConfiguredThemeMode() : undefined
+  const resolvedTheme = configuredTheme ?? theme
 
   useEffect(() => {
     if (!mounted) return
-    applyThemeMode(theme)
-    return subscribeSystemThemeChanges(theme)
-  }, [mounted, theme])
+    applyThemeMode(resolvedTheme)
+    return subscribeSystemThemeChanges(resolvedTheme)
+  }, [mounted, resolvedTheme])
 
   const toggleTheme = () => {
+    if (configuredTheme != null) {
+      return
+    }
+
     const nextTheme: ArdoThemeMode =
       theme === "light" ? "dark" : theme === "dark" ? "system" : "light"
     setTheme(nextTheme)
@@ -43,12 +50,17 @@ export function ArdoThemeToggle() {
       type="button"
       className={styles.themeToggle}
       onClick={toggleTheme}
-      aria-label={`Switch to ${theme === "light" ? "dark" : theme === "dark" ? "system" : "light"} theme`}
+      disabled={configuredTheme != null}
+      aria-label={
+        configuredTheme == null
+          ? `Switch to ${theme === "light" ? "dark" : theme === "dark" ? "system" : "light"} theme`
+          : `Theme fixed to ${configuredTheme}`
+      }
     >
       <span className={styles.themeIcon}>
-        {theme === "light" && <SunIcon size={20} />}
-        {theme === "dark" && <MoonIcon size={20} />}
-        {theme === "system" && <MonitorIcon size={20} />}
+        {resolvedTheme === "light" && <SunIcon size={20} />}
+        {resolvedTheme === "dark" && <MoonIcon size={20} />}
+        {resolvedTheme === "system" && <MonitorIcon size={20} />}
       </span>
     </button>
   )

--- a/packages/ardo/src/ui/theme-mode.test.ts
+++ b/packages/ardo/src/ui/theme-mode.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ARDO_THEME_STORAGE_KEY,
+  getArdoThemeBootstrapScript,
+  resolveThemeBootstrapState,
+} from "./theme-mode"
+
+describe("resolveThemeBootstrapState", () => {
+  it("keeps stored user preference in auto mode", () => {
+    expect(
+      resolveThemeBootstrapState({
+        prefersDark: false,
+        storedTheme: "dark",
+      })
+    ).toStrictEqual({
+      clearsStorage: false,
+      isDark: true,
+      theme: "dark",
+    })
+  })
+
+  it("can force light mode and clear stale storage", () => {
+    expect(
+      resolveThemeBootstrapState({
+        preference: "light",
+        prefersDark: true,
+        storedTheme: "dark",
+      })
+    ).toStrictEqual({
+      clearsStorage: true,
+      isDark: false,
+      theme: "light",
+    })
+  })
+
+  it("can always follow system preference without stored overrides", () => {
+    expect(
+      resolveThemeBootstrapState({
+        preference: "system",
+        prefersDark: true,
+        storedTheme: "light",
+      })
+    ).toStrictEqual({
+      clearsStorage: true,
+      isDark: true,
+      theme: "system",
+    })
+  })
+})
+
+describe("getArdoThemeBootstrapScript", () => {
+  it("embeds the configured preference and storage key", () => {
+    const script = getArdoThemeBootstrapScript("light")
+
+    expect(script).toContain('const configuredTheme = "light"')
+    expect(script).toContain(ARDO_THEME_STORAGE_KEY)
+    expect(script).toContain("localStorage.removeItem")
+  })
+})

--- a/packages/ardo/src/ui/theme-mode.ts
+++ b/packages/ardo/src/ui/theme-mode.ts
@@ -1,10 +1,40 @@
 export type ArdoThemeMode = "dark" | "light" | "system"
+export type ArdoThemePreference = "auto" | ArdoThemeMode
 
 export const ARDO_THEME_STORAGE_KEY = "ardo-theme"
-export const ARDO_THEME_BOOTSTRAP_SCRIPT = `(() => {
+
+const ARDO_THEME_DATA_ATTRIBUTE = "ardoTheme"
+
+export const ARDO_THEME_BOOTSTRAP_SCRIPT = getArdoThemeBootstrapScript()
+
+export function resolveThemeBootstrapState(params: {
+  preference?: ArdoThemePreference
+  prefersDark: boolean
+  storedTheme?: null | string
+}): { clearsStorage: boolean; isDark: boolean; theme: ArdoThemeMode } {
+  const preference = params.preference ?? "auto"
+  const stored = isThemeMode(params.storedTheme) ? params.storedTheme : "system"
+  const theme = preference === "auto" ? stored : preference
+  const isDark = theme === "dark" || (theme === "system" && params.prefersDark)
+
+  return {
+    clearsStorage: preference !== "auto",
+    isDark,
+    theme,
+  }
+}
+
+export function getArdoThemeBootstrapScript(preference: ArdoThemePreference = "auto"): string {
+  return `(() => {
   try {
+    const configuredTheme = ${JSON.stringify(preference)};
+    document.documentElement.dataset.ardoTheme = configuredTheme;
     const storedTheme = localStorage.getItem("${ARDO_THEME_STORAGE_KEY}");
-    const theme = storedTheme === "dark" || storedTheme === "light" || storedTheme === "system" ? storedTheme : "system";
+    const stored = storedTheme === "dark" || storedTheme === "light" || storedTheme === "system" ? storedTheme : "system";
+    const theme = configuredTheme === "auto" ? stored : configuredTheme;
+    if (configuredTheme !== "auto") {
+      localStorage.removeItem("${ARDO_THEME_STORAGE_KEY}");
+    }
     const prefersDark = matchMedia("(prefers-color-scheme: dark)").matches;
     const isDark = theme === "dark" || (theme === "system" && prefersDark);
     document.documentElement.classList.toggle("dark", isDark);
@@ -12,48 +42,68 @@ export const ARDO_THEME_BOOTSTRAP_SCRIPT = `(() => {
   } catch {
   }
 })();`
+}
 
 const isBrowser = typeof document !== "undefined"
 
 export function getInitialThemeMode(): ArdoThemeMode {
+  const configured = getConfiguredThemeMode()
+  if (configured != null) return configured
   if (!isBrowser) return "system"
   const stored = localStorage.getItem(ARDO_THEME_STORAGE_KEY)
   return isThemeMode(stored) ? stored : "system"
 }
 
 export function storeThemeMode(theme: ArdoThemeMode): void {
+  if (getConfiguredThemeMode() != null) {
+    localStorage.removeItem(ARDO_THEME_STORAGE_KEY)
+    return
+  }
+
   localStorage.setItem(ARDO_THEME_STORAGE_KEY, theme)
 }
 
 export function applyThemeMode(theme: ArdoThemeMode): void {
+  const configured = getConfiguredThemeMode()
+  const resolvedTheme = configured ?? theme
   const root = document.documentElement
-  const isDark = theme === "dark" || (theme === "system" && getSystemThemeQuery().matches)
+  const isDark =
+    resolvedTheme === "dark" || (resolvedTheme === "system" && getSystemThemeQuery().matches)
 
   root.classList.toggle("dark", isDark)
   root.classList.toggle("light", !isDark)
 }
 
 export function subscribeSystemThemeChanges(theme: ArdoThemeMode): () => void {
-  if (theme !== "system") {
+  const configured = getConfiguredThemeMode()
+  const resolvedTheme = configured ?? theme
+
+  if (resolvedTheme !== "system") {
     return noop
   }
 
   const query = getSystemThemeQuery()
-  const handleChange = () => {
-    applyThemeMode("system")
-  }
-
-  query.addEventListener("change", handleChange)
+  query.addEventListener("change", handleSystemThemeChange)
   return () => {
-    query.removeEventListener("change", handleChange)
+    query.removeEventListener("change", handleSystemThemeChange)
   }
+}
+
+function handleSystemThemeChange(): void {
+  applyThemeMode("system")
 }
 
 function getSystemThemeQuery(): MediaQueryList {
   return globalThis.matchMedia("(prefers-color-scheme: dark)")
 }
 
-function isThemeMode(value: null | string): value is ArdoThemeMode {
+export function getConfiguredThemeMode(): ArdoThemeMode | undefined {
+  if (!isBrowser) return undefined
+  const value = document.documentElement.dataset[ARDO_THEME_DATA_ATTRIBUTE]
+  return isThemeMode(value) ? value : undefined
+}
+
+function isThemeMode(value: null | string | undefined): value is ArdoThemeMode {
   return value === "dark" || value === "light" || value === "system"
 }
 

--- a/packages/ardo/src/ui/theme/tokens.test.ts
+++ b/packages/ardo/src/ui/theme/tokens.test.ts
@@ -29,4 +29,64 @@ describe("createTheme", () => {
     expect(theme.light.color.border).toBe("oklch(0.88 0.005 var(--ardo-hue-neutral))")
     expect(theme.dark.color.text).toBe("oklch(0.94 0.004 var(--ardo-hue-neutral))")
   })
+
+  it("merges shared token overrides into light and dark themes", () => {
+    const theme = createTheme({
+      color: {
+        bg: "#fbfbf8",
+        brand: "#0038ff",
+        brandGradient: "#0038ff",
+        shadowSm: "0 0 0 0 transparent",
+      },
+      radius: {
+        base: "0px",
+        lg: "0px",
+        sm: "0px",
+      },
+    })
+
+    expect(theme.light.hue).toStrictEqual({
+      brand: "356",
+      accent: "230",
+      neutral: "356",
+    })
+    expect(theme.light.color.bg).toBe("#fbfbf8")
+    expect(theme.dark.color.bg).toBe("#fbfbf8")
+    expect(theme.light.color.brandGradient).toBe("#0038ff")
+    expect(theme.dark.color.shadowSm).toBe("0 0 0 0 transparent")
+    expect(theme.light.radius).toStrictEqual({
+      base: "0px",
+      lg: "0px",
+      sm: "0px",
+    })
+  })
+
+  it("supports light and dark specific token overrides", () => {
+    const theme = createTheme({
+      primary: 210,
+      color: {
+        brand: "#0038ff",
+      },
+      dark: {
+        color: {
+          bg: "#101010",
+          text: "#fbfbf8",
+        },
+      },
+      light: {
+        color: {
+          bg: "#fbfbf8",
+          text: "#101010",
+        },
+      },
+    })
+
+    expect(theme.light.hue.brand).toBe("210")
+    expect(theme.light.color.brand).toBe("#0038ff")
+    expect(theme.dark.color.brand).toBe("#0038ff")
+    expect(theme.light.color.bg).toBe("#fbfbf8")
+    expect(theme.light.color.text).toBe("#101010")
+    expect(theme.dark.color.bg).toBe("#101010")
+    expect(theme.dark.color.text).toBe("#fbfbf8")
+  })
 })

--- a/packages/ardo/src/ui/theme/tokens.ts
+++ b/packages/ardo/src/ui/theme/tokens.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- This file intentionally keeps the generated token table together. */
 /**
  * Pre-computed OKLCH color values for both light and dark themes.
  * No more `calc(var(...))` chains — all values are resolved here.
@@ -8,6 +9,10 @@ import { createGlobalTheme } from "@vanilla-extract/css"
 import { vars } from "./contract.css"
 
 type HueValue = number | string
+type PrimitiveToken = number | string
+type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends PrimitiveToken ? T[K] : DeepPartial<T[K]>
+}
 
 // eslint-disable-next-line max-params -- mirrors CSS oklch() syntax
 const oklch = (l: number, c: number, h: HueValue, alpha?: number) =>
@@ -214,6 +219,7 @@ function createDarkColors() {
  * custom primary picks up an approximately complementary secondary.
  */
 const DEFAULT_SECONDARY_OFFSET = 234
+const DEFAULT_PRIMARY_HUE = 356
 
 function defaultSecondary(primary: number): number {
   return (primary + DEFAULT_SECONDARY_OFFSET) % 360
@@ -228,31 +234,127 @@ export type ArdoBrandHues = {
   neutral?: number
 }
 
-export function createTheme(primaryOrHues: ArdoBrandHues | number, secondaryArg?: number) {
-  const primary = typeof primaryOrHues === "number" ? primaryOrHues : primaryOrHues.primary
-  const explicitSecondary =
-    typeof primaryOrHues === "number" ? secondaryArg : primaryOrHues.secondary
-  const secondary = explicitSecondary ?? defaultSecondary(primary)
-  const neutral = typeof primaryOrHues === "number" ? primary : (primaryOrHues.neutral ?? primary)
+type ThemeBase = typeof shared
+type ThemeColors = ReturnType<typeof createLightColors>
+type ThemeHueTokens = {
+  brand: string
+  accent: string
+  neutral: string
+}
+
+export type ArdoThemeTokens = {
+  hue: ThemeHueTokens
+  color: ThemeColors
+} & ThemeBase
+
+export type ArdoThemeOverrides = DeepPartial<ArdoThemeTokens>
+
+export type ArdoThemeOptions = {
+  /** Overrides applied only to the generated dark token set. */
+  dark?: ArdoThemeOverrides
+  /** Overrides applied only to the generated light token set. */
+  light?: ArdoThemeOverrides
+} & ArdoThemeOverrides &
+  Partial<ArdoBrandHues>
+
+function createBaseTheme(primary: number, secondary: number, neutral: number) {
+  const hue = {
+    brand: String(primary),
+    accent: String(secondary),
+    neutral: String(neutral),
+  }
+
   return {
     light: {
-      hue: {
-        brand: String(primary),
-        accent: String(secondary),
-        neutral: String(neutral),
-      },
+      hue,
       color: createLightColors(),
       ...shared,
     },
     dark: {
-      hue: {
-        brand: String(primary),
-        accent: String(secondary),
-        neutral: String(neutral),
-      },
+      hue,
       color: createDarkColors(),
       ...shared,
     },
+  }
+}
+
+function resolveThemeHues(
+  primaryOrOptions: ArdoThemeOptions | number | undefined,
+  secondaryArg?: number
+): Required<ArdoBrandHues> {
+  const primary =
+    typeof primaryOrOptions === "number"
+      ? primaryOrOptions
+      : (primaryOrOptions?.primary ?? DEFAULT_PRIMARY_HUE)
+  const explicitSecondary =
+    typeof primaryOrOptions === "number" ? secondaryArg : primaryOrOptions?.secondary
+  const secondary = explicitSecondary ?? defaultSecondary(primary)
+  const neutral =
+    typeof primaryOrOptions === "number" ? primary : (primaryOrOptions?.neutral ?? primary)
+
+  return { neutral, primary, secondary }
+}
+
+function getSharedThemeOverrides(options: ArdoThemeOptions | undefined): ArdoThemeOverrides {
+  if (options == null) {
+    return {}
+  }
+
+  const {
+    dark: _dark,
+    light: _light,
+    neutral: _neutral,
+    primary: _primary,
+    secondary: _secondary,
+    ...overrides
+  } = options
+  return overrides
+}
+
+function mergeThemeTokens(base: ArdoThemeTokens, override: ArdoThemeOverrides): ArdoThemeTokens {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- Merging over a complete token object preserves the full token shape.
+  return mergeRecords(base, override) as ArdoThemeTokens
+}
+
+function mergeRecords(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...base }
+
+  for (const key of Object.keys(override)) {
+    const value = override[key]
+    if (value === undefined) {
+      continue
+    }
+
+    const baseValue = base[key]
+    merged[key] =
+      isPlainObject(baseValue) && isPlainObject(value) ? mergeRecords(baseValue, value) : value
+  }
+
+  return merged
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function createTheme(
+  primaryOrOptions?: ArdoThemeOptions | number,
+  secondaryArg?: number
+): { dark: ArdoThemeTokens; light: ArdoThemeTokens } {
+  const { neutral, primary, secondary } = resolveThemeHues(primaryOrOptions, secondaryArg)
+  const baseTheme = createBaseTheme(primary, secondary, neutral)
+  const options = typeof primaryOrOptions === "object" ? primaryOrOptions : undefined
+  const sharedOverrides = getSharedThemeOverrides(options)
+
+  return {
+    light: mergeThemeTokens(
+      mergeThemeTokens(baseTheme.light, sharedOverrides),
+      options?.light ?? {}
+    ),
+    dark: mergeThemeTokens(mergeThemeTokens(baseTheme.dark, sharedOverrides), options?.dark ?? {}),
   }
 }
 
@@ -260,8 +362,11 @@ const defaultTheme = createTheme(356)
 export const lightTokens = defaultTheme.light
 export const darkTokens = defaultTheme.dark
 
-export function applyBrandTheme(primaryOrHues: ArdoBrandHues | number, secondaryArg?: number) {
-  const theme = createTheme(primaryOrHues, secondaryArg)
+export function applyBrandTheme(
+  primaryOrOptions?: ArdoThemeOptions | number,
+  secondaryArg?: number
+) {
+  const theme = createTheme(primaryOrOptions, secondaryArg)
   createGlobalTheme(":root", vars, theme.light)
   createGlobalTheme(".dark", vars, theme.dark)
 }


### PR DESCRIPTION
## Summary
- extend createTheme/applyBrandTheme to accept deep token overrides while keeping hue-based calls compatible
- add explicit ArdoRootLayout theme policies for auto, light, dark, and system modes with pre-paint bootstrap behavior
- avoid duplicate visible ledes when frontmatter description matches the first paragraph, add lede:false, and stop TypeDoc from writing the default API description as body text

## Issues
Refs #246
Closes #257
Closes #258
Closes #259

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm build
- pnpm exec vitest --run packages/ardo/src/ui/theme/tokens.test.ts packages/ardo/src/ui/theme-mode.test.ts packages/ardo/src/ui/Content.test.tsx packages/ardo/src/typedoc/generator.test.ts
- pnpm test (outside sandbox; 22 files, 100 tests)
- pnpm docs:build (outside sandbox; passes with existing generated API/demo broken-link warnings)