### PR TITLE
feat: expand theme and description controls

### DIFF
--- a/docs/app/routes/guide/custom-theme.mdx
+++ b/docs/app/routes/guide/custom-theme.mdx
@@ -63,7 +63,41 @@ The default hue is `356` (a muted berry tone). Some starting points:
 | `45`  | Orange          |
 | `130` | Green           |
 
-For full control over individual tokens, use `createTheme()` instead — it returns the complete `{ light, dark }` token sets for a given hue set, which you can modify before passing to `createGlobalTheme`.
+For full control over individual tokens, pass token overrides directly. Shared overrides apply to
+both light and dark themes; `light` and `dark` override only one side.
+
+```ts
+// styles/brand.css.ts
+import { applyBrandTheme } from "ardo/theme"
+
+applyBrandTheme({
+  color: {
+    bg: "#fbfbf8",
+    brand: "#0038ff",
+    brandGradient: "#0038ff",
+    shadowSm: "0 0 0 0 transparent",
+    shadowMd: "0 0 0 0 transparent",
+    shadowLg: "0 0 0 0 transparent",
+  },
+  radius: {
+    sm: "0px",
+    base: "0px",
+    lg: "0px",
+  },
+  dark: {
+    color: {
+      bg: "#101010",
+      text: "#fbfbf8",
+    },
+  },
+})
+```
+
+Use `0 0 0 0 transparent` for empty shadows. `none` is valid CSS on its own, but it can break
+component rules that combine the shadow token with an additional ring shadow.
+
+`createTheme()` returns the complete `{ light, dark }` token sets for a hue set plus overrides when
+you need to inspect or pass the values manually to Vanilla Extract's `createGlobalTheme`.
 
 ## CSS Variables
 

--- a/docs/app/routes/guide/frontmatter.mdx
+++ b/docs/app/routes/guide/frontmatter.mdx
@@ -46,6 +46,17 @@ description: Learn how to get started with Ardo
 ---
 ```
 
+By default, Ardo also renders `description` as the visible lede below the page title. Set
+`lede: false` when the description is metadata-only or when the first body paragraph already says
+the same thing.
+
+```yaml
+---
+description: Learn how to get started with Ardo
+lede: false
+---
+```
+
 ### Social metadata
 
 Markdown routes without their own `meta` export get generated browser, canonical, Open Graph, and Twitter metadata from frontmatter and site config.

--- a/docs/app/routes/guide/site-ui.mdx
+++ b/docs/app/routes/guide/site-ui.mdx
@@ -33,6 +33,18 @@ export default function Root() {
 `ArdoRootLayout` owns the document-level theme bootstrap and global shell setup. `ArdoRoot` owns the
 React Router outlet, Ardo providers, default header, sidebar, and footer.
 
+Set `theme` on `ArdoRootLayout` when the site should force one mode instead of honoring stored user
+preferences:
+
+```tsx
+export function Layout({ children }: { children: React.ReactNode }) {
+  return <ArdoRootLayout theme="light">{children}</ArdoRootLayout>
+}
+```
+
+`theme="system"` is the default and keeps the theme toggle/storage behavior. `theme="light"` and
+`theme="dark"` apply before first paint and clear stale `ardo-theme` values from local storage.
+
 ## ArdoRoot Props
 
 | Prop             | Type                                                                               | Purpose                                                                        |

--- a/packages/ardo/src/config/types.ts
+++ b/packages/ardo/src/config/types.ts
@@ -298,6 +298,7 @@ export type PageFrontmatter = {
   outline?: [number, number] | boolean | number
   editLink?: boolean
   lastUpdated?: boolean
+  lede?: boolean
   sitemap?: boolean
   llms?: boolean
   redirectFrom?: string | string[]

--- a/packages/ardo/src/typedoc/generator-pages-index.ts
+++ b/packages/ardo/src/typedoc/generator-pages-index.ts
@@ -19,7 +19,11 @@ export function generateIndexPage(
   context: TypeDocRuntimeContext,
   grouped: GroupedReflections
 ): GeneratedApiDoc {
-  const lines: string[] = [`# ${context.config.sidebar.title}`, "", getProjectSummary(context), ""]
+  const lines: string[] = [`# ${context.config.sidebar.title}`, ""]
+  const projectSummary = getProjectSummary(context)
+  if (projectSummary != null) {
+    lines.push(projectSummary, "")
+  }
 
   appendComponentSection(lines, context, grouped.componentItems)
   appendFunctionsSection(lines, context, grouped.functionsByFile)
@@ -37,10 +41,10 @@ export function generateIndexPage(
   }
 }
 
-function getProjectSummary(context: TypeDocRuntimeContext): string {
+function getProjectSummary(context: TypeDocRuntimeContext): null | string {
   const summary = context.project.comment?.summary
   if (summary == null) {
-    return "Auto-generated API documentation."
+    return null
   }
   return renderComment(summary)
 }

--- a/packages/ardo/src/typedoc/generator.test.ts
+++ b/packages/ardo/src/typedoc/generator.test.ts
@@ -1,9 +1,13 @@
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
+import { FileRegistry, ProjectReflection } from "typedoc"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
+import type { TypeDocRuntimeContext } from "./generator-config"
+
 import { prepareGeneratedDocsDirectory, resolveGeneratedDocsDirectory } from "./generator"
+import { generateIndexPage } from "./generator-pages-index"
 
 let routesDir: string
 
@@ -54,3 +58,46 @@ describe("prepareGeneratedDocsDirectory", () => {
     await expect(fs.access(apiDirectory)).rejects.toThrow("ENOENT")
   })
 })
+
+describe("generateIndexPage", () => {
+  it("does not duplicate the default API description in the body", () => {
+    const doc = generateIndexPage(createTypeDocContext(), {
+      componentItems: [],
+      functionsByFile: new Map(),
+      standaloneItems: [],
+      typesByFile: new Map(),
+    })
+
+    expect(doc.frontmatter.description).toBe("Auto-generated API documentation")
+    expect(doc.content).toBe("# API Reference\n")
+    expect(doc.content).not.toContain("Auto-generated API documentation")
+  })
+})
+
+function createTypeDocContext(): TypeDocRuntimeContext {
+  return {
+    basePath: "/api-reference",
+    config: {
+      entryPoints: ["src/index.ts"],
+      excludeExternals: true,
+      excludeInternal: true,
+      excludePrivate: true,
+      excludeProtected: false,
+      markdown: {
+        breadcrumbs: true,
+        codeBlocks: true,
+        hierarchy: true,
+        sourceLinks: true,
+      },
+      out: "api-reference",
+      sidebar: {
+        collapsed: false,
+        position: 100,
+        title: "API Reference",
+      },
+      sort: ["source-order"],
+    },
+    packageNameCache: new Map(),
+    project: new ProjectReflection("ardo", new FileRegistry()),
+  }
+}

--- a/packages/ardo/src/typedoc/generator.ts
+++ b/packages/ardo/src/typedoc/generator.ts
@@ -101,6 +101,10 @@ function createFrontmatter(doc: GeneratedApiDoc): string {
     lines.push(`description: ${doc.frontmatter.description}`)
   }
 
+  if (doc.frontmatter.lede === false) {
+    lines.push("lede: false")
+  }
+
   if (doc.frontmatter.sidebar_position != null) {
     lines.push(`sidebar_position: ${doc.frontmatter.sidebar_position}`)
   }

--- a/packages/ardo/src/typedoc/types.ts
+++ b/packages/ardo/src/typedoc/types.ts
@@ -225,6 +225,7 @@ export type GeneratedApiDoc = {
   frontmatter: {
     title: string
     description?: string
+    lede?: boolean
     sidebar_position?: number
     sidebar?: "leaf" | boolean
   }

--- a/packages/ardo/src/ui/Content.test.tsx
+++ b/packages/ardo/src/ui/Content.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { MemoryRouter } from "react-router"
+import { describe, expect, it } from "vitest"
+
+import { ArdoPageDataProvider, ArdoProvider } from "../runtime/hooks"
+import { ArdoContent } from "./Content"
+
+function renderContent(lede: boolean): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <ArdoProvider config={{ title: "Docs" }} sidebar={[]}>
+        <ArdoPageDataProvider
+          frontmatter={{
+            description: "Install the package and import the provider.",
+            lede,
+            title: "Guide",
+          }}
+          toc={[]}
+        >
+          <ArdoContent>
+            <p>Install the package and import the provider.</p>
+          </ArdoContent>
+        </ArdoPageDataProvider>
+      </ArdoProvider>
+    </MemoryRouter>
+  )
+}
+
+describe("ArdoContent", () => {
+  it("renders frontmatter descriptions as a visible lede by default", () => {
+    const view = renderContent(true)
+
+    expect(view.match(/Install the package and import the provider\./g)).toHaveLength(2)
+  })
+
+  it("allows frontmatter descriptions to be metadata only", () => {
+    const view = renderContent(false)
+
+    expect(view.match(/Install the package and import the provider\./g)).toHaveLength(1)
+  })
+})

--- a/packages/ardo/src/ui/Content.tsx
+++ b/packages/ardo/src/ui/Content.tsx
@@ -86,6 +86,7 @@ export function ArdoContent({
       <ContentHeader
         title={pageData?.frontmatter.title ?? ""}
         description={pageData?.frontmatter.description ?? ""}
+        lede={pageData?.frontmatter.lede !== false}
       />
       <div className={`${docStyles.contentBody} ${ardoContent}`}>{children}</div>
       {metaPlacement === "footer" && <ContentMeta edit={edit} updated={updated} />}
@@ -94,12 +95,20 @@ export function ArdoContent({
   )
 }
 
-function ContentHeader({ title, description }: { title: string; description: string }) {
+function ContentHeader({
+  title,
+  description,
+  lede,
+}: {
+  description: string
+  lede: boolean
+  title: string
+}) {
   if (title === "") return null
   return (
     <header className={docStyles.contentHeader}>
       <h1 className={docStyles.contentTitle}>{title}</h1>
-      {description !== "" && <p className={docStyles.contentDescription}>{description}</p>}
+      {lede && description !== "" && <p className={docStyles.contentDescription}>{description}</p>}
     </header>
   )
 }

--- a/packages/ardo/src/ui/Layout.tsx
+++ b/packages/ardo/src/ui/Layout.tsx
@@ -4,7 +4,7 @@ import { Links, Meta, Scripts, ScrollRestoration } from "react-router"
 import { ArdoContext } from "../runtime/hooks"
 import { ARDO_FAVICON_DATA_URL } from "./favicon"
 import * as styles from "./Layout.css"
-import { ARDO_THEME_BOOTSTRAP_SCRIPT } from "./theme-mode"
+import { type ArdoThemeMode, createThemeBootstrapScript } from "./theme-mode"
 
 // =============================================================================
 // RootLayout Component (html/head/body shell)
@@ -21,6 +21,8 @@ export type ArdoRootLayoutProps = {
   iconBasePath?: false | string
   /** Language attribute for <html> (default: from config or "en") */
   lang?: string
+  /** Theme policy applied before first paint. Defaults to stored/system preference. */
+  theme?: ArdoThemeMode
 }
 
 /**
@@ -44,6 +46,7 @@ export function ArdoRootLayout({
   favicon,
   iconBasePath = "/",
   lang,
+  theme = "system",
 }: ArdoRootLayoutProps) {
   // Use optional context (RootLayout renders before ArdoProvider is available)
   const context = use(ArdoContext)
@@ -51,11 +54,11 @@ export function ArdoRootLayout({
   const iconBaseUrl = iconBasePath === false ? undefined : normalizeIconBasePath(iconBasePath)
 
   return (
-    <html lang={resolvedLang} suppressHydrationWarning>
+    <html lang={resolvedLang} data-ardo-theme={theme} suppressHydrationWarning>
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <script dangerouslySetInnerHTML={{ __html: ARDO_THEME_BOOTSTRAP_SCRIPT }} />
+        <script dangerouslySetInnerHTML={{ __html: createThemeBootstrapScript(theme) }} />
         {iconBaseUrl == null ? (
           <link rel="icon" type="image/svg+xml" href={favicon ?? ARDO_FAVICON_DATA_URL} />
         ) : (

--- a/packages/ardo/src/ui/components/ThemeToggle.tsx
+++ b/packages/ardo/src/ui/components/ThemeToggle.tsx
@@ -4,6 +4,7 @@ import { MonitorIcon, MoonIcon, SunIcon } from "../icons"
 import {
   applyThemeMode,
   type ArdoThemeMode,
+  getConfiguredThemeMode,
   getInitialThemeMode,
   storeThemeMode,
   subscribeSystemThemeChanges,
@@ -13,6 +14,7 @@ import * as styles from "./ThemeToggle.css"
 export function ArdoThemeToggle() {
   const [theme, setTheme] = useState<ArdoThemeMode>(getInitialThemeMode)
   const mounted = useSyncExternalStore(subscribeMounted, getClientMounted, getServerMounted)
+  const configuredTheme = mounted ? getConfiguredThemeMode() : "system"
 
   useEffect(() => {
     if (!mounted) return
@@ -26,6 +28,10 @@ export function ArdoThemeToggle() {
     setTheme(nextTheme)
     storeThemeMode(nextTheme)
     applyThemeMode(nextTheme)
+  }
+
+  if (mounted && configuredTheme !== "system") {
+    return null
   }
 
   if (!mounted) {

--- a/packages/ardo/src/ui/theme-mode.test.ts
+++ b/packages/ardo/src/ui/theme-mode.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { ARDO_THEME_STORAGE_KEY, createThemeBootstrapScript } from "./theme-mode"
+
+describe("createThemeBootstrapScript", () => {
+  it("defaults to stored or system theme mode", () => {
+    const script = createThemeBootstrapScript()
+
+    expect(script).toContain('const configuredTheme = "system"')
+    expect(script).toContain(`localStorage.getItem("${ARDO_THEME_STORAGE_KEY}")`)
+    expect(script).toContain("prefers-color-scheme: dark")
+  })
+
+  it("forces fixed light and dark modes to ignore stale stored preferences", () => {
+    const lightScript = createThemeBootstrapScript("light")
+    const darkScript = createThemeBootstrapScript("dark")
+
+    expect(lightScript).toContain('const configuredTheme = "light"')
+    expect(lightScript).toContain(`localStorage.removeItem("${ARDO_THEME_STORAGE_KEY}")`)
+    expect(darkScript).toContain('const configuredTheme = "dark"')
+    expect(darkScript).toContain(`localStorage.removeItem("${ARDO_THEME_STORAGE_KEY}")`)
+  })
+})

--- a/packages/ardo/src/ui/theme-mode.ts
+++ b/packages/ardo/src/ui/theme-mode.ts
@@ -1,40 +1,61 @@
 export type ArdoThemeMode = "dark" | "light" | "system"
 
 export const ARDO_THEME_STORAGE_KEY = "ardo-theme"
-export const ARDO_THEME_BOOTSTRAP_SCRIPT = `(() => {
+
+export function createThemeBootstrapScript(theme: ArdoThemeMode = "system"): string {
+  return `(() => {
   try {
-    const storedTheme = localStorage.getItem("${ARDO_THEME_STORAGE_KEY}");
+    const configuredTheme = ${JSON.stringify(theme)};
+    if (configuredTheme === "light" || configuredTheme === "dark") {
+      localStorage.removeItem("${ARDO_THEME_STORAGE_KEY}");
+    }
+    const storedTheme = configuredTheme === "system" ? localStorage.getItem("${ARDO_THEME_STORAGE_KEY}") : configuredTheme;
     const theme = storedTheme === "dark" || storedTheme === "light" || storedTheme === "system" ? storedTheme : "system";
     const prefersDark = matchMedia("(prefers-color-scheme: dark)").matches;
     const isDark = theme === "dark" || (theme === "system" && prefersDark);
+    document.documentElement.dataset.ardoTheme = configuredTheme;
     document.documentElement.classList.toggle("dark", isDark);
     document.documentElement.classList.toggle("light", !isDark);
   } catch {
   }
 })();`
+}
 
 const isBrowser = typeof document !== "undefined"
 
+export const ARDO_THEME_BOOTSTRAP_SCRIPT = createThemeBootstrapScript()
+
 export function getInitialThemeMode(): ArdoThemeMode {
   if (!isBrowser) return "system"
+  const configured = getConfiguredThemeMode()
+  if (configured !== "system") return configured
   const stored = localStorage.getItem(ARDO_THEME_STORAGE_KEY)
   return isThemeMode(stored) ? stored : "system"
 }
 
 export function storeThemeMode(theme: ArdoThemeMode): void {
+  if (getConfiguredThemeMode() !== "system") {
+    localStorage.removeItem(ARDO_THEME_STORAGE_KEY)
+    return
+  }
   localStorage.setItem(ARDO_THEME_STORAGE_KEY, theme)
 }
 
 export function applyThemeMode(theme: ArdoThemeMode): void {
   const root = document.documentElement
-  const isDark = theme === "dark" || (theme === "system" && getSystemThemeQuery().matches)
+  const configured = getConfiguredThemeMode()
+  const resolvedTheme = configured === "system" ? theme : configured
+  const isDark =
+    resolvedTheme === "dark" || (resolvedTheme === "system" && getSystemThemeQuery().matches)
 
   root.classList.toggle("dark", isDark)
   root.classList.toggle("light", !isDark)
 }
 
 export function subscribeSystemThemeChanges(theme: ArdoThemeMode): () => void {
-  if (theme !== "system") {
+  const configured = getConfiguredThemeMode()
+  const resolvedTheme = configured === "system" ? theme : configured
+  if (resolvedTheme !== "system") {
     return noop
   }
 
@@ -55,6 +76,12 @@ function getSystemThemeQuery(): MediaQueryList {
 
 function isThemeMode(value: null | string): value is ArdoThemeMode {
   return value === "dark" || value === "light" || value === "system"
+}
+
+export function getConfiguredThemeMode(): ArdoThemeMode {
+  if (!isBrowser) return "system"
+  const configured = document.documentElement.dataset.ardoTheme ?? null
+  return isThemeMode(configured) ? configured : "system"
 }
 
 function noop() {

--- a/packages/ardo/src/ui/theme/index.ts
+++ b/packages/ardo/src/ui/theme/index.ts
@@ -1,2 +1,11 @@
 export { vars } from "./contract.css"
-export { applyBrandTheme, type ArdoBrandHues, createTheme } from "./tokens"
+export {
+  applyBrandTheme,
+  type ArdoBrandHues,
+  type ArdoTheme,
+  type ArdoThemeInput,
+  type ArdoThemeOptions,
+  type ArdoThemeTokenOverrides,
+  type ArdoThemeTokens,
+  createTheme,
+} from "./tokens"

--- a/packages/ardo/src/ui/theme/merge.ts
+++ b/packages/ardo/src/ui/theme/merge.ts
@@ -1,0 +1,31 @@
+import type { ArdoThemeTokenOverrides, ArdoThemeTokens } from "./tokens"
+
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends Record<string, unknown> ? DeepPartial<T[K]> : T[K]
+}
+
+export function mergeThemeTokens(
+  base: ArdoThemeTokens,
+  ...overrides: Array<ArdoThemeTokenOverrides | undefined>
+): ArdoThemeTokens {
+  let merged = base
+  for (const override of overrides) {
+    if (override == null) {
+      continue
+    }
+
+    merged = {
+      ...merged,
+      ...override,
+      color: { ...merged.color, ...override.color },
+      font: { ...merged.font, ...override.font },
+      fontSize: { ...merged.fontSize, ...override.fontSize },
+      hue: { ...merged.hue, ...override.hue },
+      layout: { ...merged.layout, ...override.layout },
+      radius: { ...merged.radius, ...override.radius },
+      space: { ...merged.space, ...override.space },
+      transition: { ...merged.transition, ...override.transition },
+    }
+  }
+  return merged
+}

--- a/packages/ardo/src/ui/theme/tokens.test.ts
+++ b/packages/ardo/src/ui/theme/tokens.test.ts
@@ -29,4 +29,51 @@ describe("createTheme", () => {
     expect(theme.light.color.border).toBe("oklch(0.88 0.005 var(--ardo-hue-neutral))")
     expect(theme.dark.color.text).toBe("oklch(0.94 0.004 var(--ardo-hue-neutral))")
   })
+
+  it("applies shared token overrides to both themes", () => {
+    const theme = createTheme({
+      color: {
+        bg: "#fbfbf8",
+        brand: "#0038ff",
+        brandGradient: "#0038ff",
+        shadowSm: "0 0 0 0 transparent",
+      },
+      radius: {
+        base: "0px",
+        lg: "0px",
+        sm: "0px",
+      },
+    })
+
+    expect(theme.light.color.bg).toBe("#fbfbf8")
+    expect(theme.dark.color.bg).toBe("#fbfbf8")
+    expect(theme.light.color.brand).toBe("#0038ff")
+    expect(theme.light.color.brandGradient).toBe("#0038ff")
+    expect(theme.light.color.shadowSm).toBe("0 0 0 0 transparent")
+    expect(theme.dark.radius).toStrictEqual({ base: "0px", lg: "0px", sm: "0px" })
+  })
+
+  it("supports light and dark specific token overrides", () => {
+    const theme = createTheme({
+      dark: {
+        color: {
+          bg: "#101010",
+          text: "#fbfbf8",
+        },
+      },
+      light: {
+        color: {
+          bg: "#fbfbf8",
+          text: "#101010",
+        },
+      },
+      primary: 220,
+    })
+
+    expect(theme.light.hue.brand).toBe("220")
+    expect(theme.light.color.bg).toBe("#fbfbf8")
+    expect(theme.light.color.text).toBe("#101010")
+    expect(theme.dark.color.bg).toBe("#101010")
+    expect(theme.dark.color.text).toBe("#fbfbf8")
+  })
 })

--- a/packages/ardo/src/ui/theme/tokens.ts
+++ b/packages/ardo/src/ui/theme/tokens.ts
@@ -6,6 +6,7 @@
 import { createGlobalTheme } from "@vanilla-extract/css"
 
 import { vars } from "./contract.css"
+import { type DeepPartial, mergeThemeTokens } from "./merge"
 
 type HueValue = number | string
 
@@ -228,13 +229,42 @@ export type ArdoBrandHues = {
   neutral?: number
 }
 
-export function createTheme(primaryOrHues: ArdoBrandHues | number, secondaryArg?: number) {
-  const primary = typeof primaryOrHues === "number" ? primaryOrHues : primaryOrHues.primary
-  const explicitSecondary =
-    typeof primaryOrHues === "number" ? secondaryArg : primaryOrHues.secondary
+type ArdoThemeHueTokens = {
+  brand: string
+  accent: string
+  neutral: string
+}
+
+export type ArdoThemeTokens = {
+  color: ReturnType<typeof createLightColors>
+  hue: ArdoThemeHueTokens
+} & typeof shared
+
+export type ArdoTheme = {
+  dark: ArdoThemeTokens
+  light: ArdoThemeTokens
+}
+
+export type ArdoThemeTokenOverrides = DeepPartial<ArdoThemeTokens>
+
+export type ArdoThemeOptions = {
+  /** Overrides applied only to the generated dark token set. */
+  dark?: ArdoThemeTokenOverrides
+  /** Overrides applied only to the generated light token set. */
+  light?: ArdoThemeTokenOverrides
+} & ArdoThemeTokenOverrides &
+  Partial<ArdoBrandHues>
+
+export type ArdoThemeInput = ArdoThemeOptions | number
+
+export function createTheme(primaryOrHues: ArdoThemeInput = 356, secondaryArg?: number): ArdoTheme {
+  const isNumberInput = typeof primaryOrHues === "number"
+  const input: ArdoThemeOptions | undefined = isNumberInput ? undefined : primaryOrHues
+  const primary = isNumberInput ? primaryOrHues : (input?.primary ?? 356)
+  const explicitSecondary = isNumberInput ? secondaryArg : input?.secondary
   const secondary = explicitSecondary ?? defaultSecondary(primary)
-  const neutral = typeof primaryOrHues === "number" ? primary : (primaryOrHues.neutral ?? primary)
-  return {
+  const neutral = isNumberInput ? primary : (input?.neutral ?? primary)
+  const baseTheme: ArdoTheme = {
     light: {
       hue: {
         brand: String(primary),
@@ -254,13 +284,31 @@ export function createTheme(primaryOrHues: ArdoBrandHues | number, secondaryArg?
       ...shared,
     },
   }
+
+  if (input == null) {
+    return baseTheme
+  }
+
+  const {
+    dark,
+    light,
+    neutral: _neutral,
+    primary: _primary,
+    secondary: _secondary,
+    ...sharedOverrides
+  } = input
+
+  return {
+    light: mergeThemeTokens(baseTheme.light, sharedOverrides, light),
+    dark: mergeThemeTokens(baseTheme.dark, sharedOverrides, dark),
+  }
 }
 
 const defaultTheme = createTheme(356)
 export const lightTokens = defaultTheme.light
 export const darkTokens = defaultTheme.dark
 
-export function applyBrandTheme(primaryOrHues: ArdoBrandHues | number, secondaryArg?: number) {
+export function applyBrandTheme(primaryOrHues: ArdoThemeInput = 356, secondaryArg?: number) {
   const theme = createTheme(primaryOrHues, secondaryArg)
   createGlobalTheme(":root", vars, theme.light)
   createGlobalTheme(".dark", vars, theme.dark)


### PR DESCRIPTION
## Summary
- allow createTheme/applyBrandTheme to accept nested token overrides with light/dark-specific overrides
- add an ArdoRootLayout theme policy for forced light/dark sites and hide the toggle when fixed
- add lede: false support and stop TypeDoc from duplicating the default API description in generated page bodies

## Validation
- pnpm exec vitest --run packages/ardo/src/ui/theme/tokens.test.ts packages/ardo/src/ui/theme-mode.test.ts packages/ardo/src/ui/Content.test.tsx packages/ardo/src/typedoc/generator.test.ts
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm build
- pnpm docs:build
- pnpm test

Refs #246
Stacked on #264
Closes #257
Closes #258
Closes #259