### PR TITLE
feat: refine default UI to a calmer, more sophisticated baseline

### DIFF
--- a/packages/ardo/src/ui/Sidebar.css.ts
+++ b/packages/ardo/src/ui/Sidebar.css.ts
@@ -21,7 +21,7 @@ export const sidebarRail = style({
   flexShrink: 0,
   padding: `${vars.space.md} 0`,
   borderRight: `1px solid ${vars.color.sidebarBorder}`,
-  background: vars.color.bgSoft,
+  background: "transparent",
 })
 
 export const sidebarRailItem = style({
@@ -68,27 +68,25 @@ export const sidebarRailLink = style({
   justifyContent: "center",
   width: "2.5rem",
   height: "2.5rem",
-  color: vars.color.textLight,
+  color: vars.color.textLighter,
   borderRadius: vars.radius.base,
   textDecoration: "none",
-  transition: `background ${vars.transition.fast}, color ${vars.transition.fast}, box-shadow ${vars.transition.fast}`,
+  transition: `background ${vars.transition.fast}, color ${vars.transition.fast}`,
   selectors: {
     "&:hover": {
       color: vars.color.text,
-      background: vars.color.bg,
-      boxShadow: vars.color.shadowSm,
+      background: vars.color.bgMute,
     },
     "&.active": {
       color: vars.color.brand,
-      background: vars.color.brandSubtle,
-      boxShadow: `inset 0 0 0 1px ${vars.color.borderLight}`,
+      background: vars.color.bgMute,
     },
     "&.active::before": {
       content: '""',
       position: "absolute",
       left: "-0.75rem",
-      top: "0.75rem",
-      bottom: "0.75rem",
+      top: "0.6rem",
+      bottom: "0.6rem",
       width: "2px",
       borderRadius: "999px",
       background: vars.color.brand,
@@ -123,8 +121,10 @@ export const sidebarList = style({
 export const sidebarList0 = style({})
 
 export const sidebarList1 = style({
-  marginLeft: "0.75rem",
+  marginLeft: "0.5rem",
   marginTop: "2px",
+  paddingLeft: "0.75rem",
+  borderLeft: `1px solid ${vars.color.divider}`,
 })
 
 export const sidebarItem = style({})
@@ -150,23 +150,21 @@ export const sidebarItemHeader = style({
 
 export const sidebarLink = style({
   display: "block",
-  padding: `0.375rem 0.75rem`,
+  padding: `0.375rem 0.625rem`,
   color: vars.color.textLight,
   textDecoration: "none",
   fontSize: vars.fontSize.sm,
   fontWeight: 400,
-  borderLeft: "2px solid transparent",
-  borderRadius: `0 ${vars.radius.base} ${vars.radius.base} 0`,
-  transition: `all ${vars.transition.fast}`,
+  borderRadius: vars.radius.base,
+  transition: `color ${vars.transition.fast}, background ${vars.transition.fast}`,
   selectors: {
     "&:hover": {
       color: vars.color.text,
-      background: vars.color.bgSoft,
+      background: vars.color.bgMute,
     },
     "&.active": {
       color: vars.color.brand,
-      background: vars.color.brandSubtle,
-      borderLeftColor: vars.color.brand,
+      background: `color-mix(in oklch, ${vars.color.brand} 9%, transparent)`,
       fontWeight: 500,
     },
   },
@@ -177,8 +175,8 @@ export const sidebarText = style({
   display: "flex",
   alignItems: "center",
   gap: vars.space.sm,
-  padding: `0.5rem 0.75rem 0.375rem`,
-  color: vars.color.textLight,
+  padding: `0.5rem 0.625rem 0.375rem`,
+  color: vars.color.text,
   textDecoration: "none",
   fontWeight: 600,
   fontSize: vars.fontSize.sm,

--- a/packages/ardo/src/ui/components/Features.css.ts
+++ b/packages/ardo/src/ui/components/Features.css.ts
@@ -58,6 +58,7 @@ export const feature = style({
   background: vars.color.bg,
   borderRadius: vars.radius.lg,
   border: `1px solid ${vars.color.border}`,
+  boxShadow: vars.color.shadowSm,
   transition: `border-color ${vars.transition.base}, box-shadow ${vars.transition.base}, transform ${vars.transition.base}`,
   animation: `${fadeInUp} 0.5s ease both`,
   selectors: {

--- a/packages/ardo/src/ui/components/Features.css.ts
+++ b/packages/ardo/src/ui/components/Features.css.ts
@@ -3,9 +3,6 @@ import { globalStyle, style } from "@vanilla-extract/css"
 import { fadeInUp } from "../theme/animations.css"
 import { vars } from "../theme/contract.css"
 
-const brandBorder = `color-mix(in oklch, ${vars.color.brand} 38%, ${vars.color.border})`
-const brandRing = `color-mix(in oklch, ${vars.color.brand} 12%, transparent)`
-
 export const features = style({
   padding: "80px 24px",
   background: vars.color.bgSoft,
@@ -61,20 +58,19 @@ export const feature = style({
   background: vars.color.bg,
   borderRadius: vars.radius.lg,
   border: `1px solid ${vars.color.border}`,
-  boxShadow: vars.color.shadowSm,
-  transition: `all ${vars.transition.base}`,
+  transition: `border-color ${vars.transition.base}, box-shadow ${vars.transition.base}, transform ${vars.transition.base}`,
   animation: `${fadeInUp} 0.5s ease both`,
   selectors: {
     "&:hover": {
-      borderColor: brandBorder,
-      boxShadow: `${vars.color.shadowMd}, 0 0 0 1px ${brandRing}`,
+      borderColor: `color-mix(in oklch, ${vars.color.brand} 22%, ${vars.color.border})`,
+      boxShadow: vars.color.shadowMd,
     },
   },
   "@media": {
     "(hover: hover)": {
       selectors: {
         "&:hover": {
-          transform: "translateY(-3px)",
+          transform: "translateY(-2px)",
         },
       },
     },
@@ -100,20 +96,12 @@ export const featureIcon = style({
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
-  width: "48px",
-  height: "48px",
-  marginBottom: "16px",
+  width: "40px",
+  height: "40px",
+  marginBottom: "18px",
   background: vars.color.brandSubtle,
-  border: `1px solid color-mix(in oklch, ${vars.color.brand} 16%, ${vars.color.border})`,
-  borderRadius: "50%",
+  borderRadius: vars.radius.base,
   color: vars.color.brand,
-  transition: `all ${vars.transition.base}`,
-})
-
-globalStyle(`${feature}:hover ${featureIcon}`, {
-  background: vars.color.brand,
-  color: "white",
-  borderColor: "transparent",
 })
 
 export const featureTitle = style({

--- a/packages/ardo/src/ui/components/Hero.css.ts
+++ b/packages/ardo/src/ui/components/Hero.css.ts
@@ -3,17 +3,17 @@ import { globalStyle, style } from "@vanilla-extract/css"
 import { fadeInUp } from "../theme/animations.css"
 import { vars } from "../theme/contract.css"
 
-const brandHalo = `color-mix(in oklch, ${vars.color.brand} 26%, transparent)`
-const brandHaloStrong = `color-mix(in oklch, ${vars.color.brand} 36%, transparent)`
-const brandTint = `color-mix(in oklch, ${vars.color.brand} 10%, transparent)`
-const brandTintSoft = `color-mix(in oklch, ${vars.color.brand} 6%, transparent)`
+const buttonShadow = `0 1px 2px oklch(0 0 0 / 0.08)`
+const buttonShadowHover = `0 4px 12px oklch(0 0 0 / 0.12)`
 
 export const hero = style({
-  padding: "100px 24px 80px",
+  padding: "104px 24px 72px",
   textAlign: "center",
   position: "relative",
   overflow: "hidden",
   selectors: {
+    // A single, quiet vertical wash — no brand glow. Reads as a calm
+    // documentation surface rather than a marketing splash.
     "&::before": {
       content: '""',
       position: "absolute",
@@ -21,16 +21,13 @@ export const hero = style({
       left: 0,
       right: 0,
       bottom: 0,
-      background: `radial-gradient(ellipse 60% 50% at 30% 0%, ${brandTintSoft} 0%, transparent 60%), radial-gradient(ellipse 80% 50% at 70% -10%, ${brandTint} 0%, transparent 70%), linear-gradient(180deg, ${vars.color.bg} 0%, ${vars.color.bgSoft} 100%)`,
+      background: `linear-gradient(180deg, ${vars.color.bgSoft} 0%, ${vars.color.bg} 100%)`,
       pointerEvents: "none",
-    },
-    ".dark &::before": {
-      background: `radial-gradient(ellipse 60% 50% at 30% 0%, color-mix(in oklch, ${vars.color.brand} 12%, transparent) 0%, transparent 60%), radial-gradient(ellipse 80% 50% at 70% -10%, color-mix(in oklch, ${vars.color.brand} 18%, transparent) 0%, transparent 70%), linear-gradient(180deg, ${vars.color.bg} 0%, ${vars.color.bgSoft} 100%)`,
     },
   },
   "@media": {
     "(max-width: 768px)": {
-      padding: "60px 20px",
+      padding: "64px 20px 48px",
     },
   },
 })
@@ -52,9 +49,9 @@ export const heroAnimate = style({
 })
 
 globalStyle(`${hero} img`, {
-  maxWidth: "180px",
-  marginBottom: "40px",
-  filter: "drop-shadow(0 4px 18px oklch(0 0 0 / 0.12))",
+  maxWidth: "148px",
+  marginBottom: "36px",
+  filter: "drop-shadow(0 2px 10px oklch(0 0 0 / 0.08))",
 })
 
 export const heroVersion = style({
@@ -71,32 +68,30 @@ export const heroVersion = style({
 })
 
 export const heroName = style({
-  fontSize: "64px",
+  fontSize: "58px",
   fontWeight: 800,
-  background: vars.color.brandGradient,
-  WebkitBackgroundClip: "text",
-  WebkitTextFillColor: "transparent",
-  backgroundClip: "text",
-  letterSpacing: "-0.03em",
+  color: vars.color.text,
+  letterSpacing: "-0.035em",
   lineHeight: 1.1,
   textWrap: "balance",
   "@media": {
     "(max-width: 768px)": {
-      fontSize: "40px",
+      fontSize: "38px",
     },
   },
 })
 
 export const heroText = style({
-  fontSize: "48px",
-  fontWeight: 700,
-  marginTop: "8px",
+  fontSize: "40px",
+  fontWeight: 600,
+  color: vars.color.textLight,
+  marginTop: "10px",
   letterSpacing: "-0.02em",
-  lineHeight: 1.15,
+  lineHeight: 1.18,
   textWrap: "balance",
   "@media": {
     "(max-width: 768px)": {
-      fontSize: "28px",
+      fontSize: "26px",
     },
   },
 })
@@ -140,11 +135,11 @@ export const heroAction = style({
 export const heroActionBrand = style({
   background: vars.color.brand,
   color: "white",
-  boxShadow: `0 4px 14px ${brandHalo}`,
+  boxShadow: buttonShadow,
   selectors: {
     "&:hover": {
       background: vars.color.brandDark,
-      boxShadow: `0 6px 20px ${brandHaloStrong}`,
+      boxShadow: buttonShadowHover,
     },
   },
   "@media": {

--- a/packages/ardo/src/ui/components/Hero.css.ts
+++ b/packages/ardo/src/ui/components/Hero.css.ts
@@ -3,9 +3,6 @@ import { globalStyle, style } from "@vanilla-extract/css"
 import { fadeInUp } from "../theme/animations.css"
 import { vars } from "../theme/contract.css"
 
-const buttonShadow = `0 1px 2px oklch(0 0 0 / 0.08)`
-const buttonShadowHover = `0 4px 12px oklch(0 0 0 / 0.12)`
-
 export const hero = style({
   padding: "104px 24px 72px",
   textAlign: "center",
@@ -135,11 +132,11 @@ export const heroAction = style({
 export const heroActionBrand = style({
   background: vars.color.brand,
   color: "white",
-  boxShadow: buttonShadow,
+  boxShadow: vars.color.shadowSm,
   selectors: {
     "&:hover": {
       background: vars.color.brandDark,
-      boxShadow: buttonShadowHover,
+      boxShadow: vars.color.shadowMd,
     },
   },
   "@media": {


### PR DESCRIPTION
## Description

Visual polish of the scaffolded default UI so it reads as **restrained and high-end** rather than template-like. No new components, no API changes — only refinements to existing styles in three files.

**Hero**
- Replace the gradient-clipped (`background-clip: text`) wordmark with a solid, tokenized color.
- Quiet the background: the layered brand radial-glow halos are replaced by a single, calm vertical `bgSoft → bg` wash.
- Swap the colored brand glow under the primary button for a neutral, restrained shadow.
- Slightly tighten the logo/type scale and let the value-prop headline sit in a lighter tone for a calmer hierarchy.

**Features**
- Replace the circular icon badge (which inverted to a filled brand circle on hover) with a calm rounded icon tile that stays consistent.
- Soften the card hover: drop the brand glow-ring, gentler lift, subtle brand-tinted border.

**Sidebar** (the main focus)
- Neutralize the loud brand-filled active states in both the icon rail and the link list. Brand color is now reserved for *text and small indicators*; surfaces stay quiet and neutral.
- Fully round the active link pill (was rounded-right-only) and drop the saturated fill for a faint tint.
- Add a hairline indent guide for nested groups so deeper navigation has real structure.

## Motivation and Context

Closes #181 (make the default Hero and Feature sections feel less template-like), which explicitly asks to drop gradient text and quiet the decorative gradient-heavy hero. Extended per maintainer request to also address the left sidebar, which felt unpolished — the goal was *schlicht + sophisticated*: calm, but high-end. The common thread across all three areas was over-saturated brand surfaces and SaaS-template hover gimmicks; the fix keeps the brand hue for accents and makes surfaces restrained.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm format` and `pnpm lint`
- [ ] I have added tests that prove my fix/feature works (if applicable) — visual-only CSS change; verified via rendered screenshots
- [ ] I have updated the documentation (if applicable) — n/a
- [x] All existing tests pass (`pnpm test`) — 143 unit tests pass; `pnpm docs:build` succeeds
- [x] TypeScript compiles without errors (`pnpm typecheck`)

## Screenshots

Verified by rendering the docs site (light + dark) before and after:

- **Hero:** gradient wordmark → solid tokenized color; brand glow halos → quiet wash; colored button glow → neutral shadow.
- **Features:** circular hover-inverting badge → calm rounded tile; glow-ring hover → subtle border + gentle lift.
- **Sidebar:** loud pink rail square + saturated active pill → quiet neutral surfaces with brand-only text/indicators, rounded active pill, nested indent guide.

## Additional Notes

Both light and dark themes were checked. All colors continue to flow through the existing OKLCH token contract (no hard-coded palette values), so custom brand hues and theme overrides keep working. `prefers-reduced-motion` behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWPohB6tJBumo2YHBz8HTL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWPohB6tJBumo2YHBz8HTL)_