### PR TITLE
fix: correct full-bleed layout seams and orphaned sidebar rail indicator

### DIFF
--- a/packages/ardo/src/ui/Sidebar.css.ts
+++ b/packages/ardo/src/ui/Sidebar.css.ts
@@ -81,16 +81,6 @@ export const sidebarRailLink = style({
       color: vars.color.brand,
       background: vars.color.bgMute,
     },
-    "&.active::before": {
-      content: '""',
-      position: "absolute",
-      left: "-0.75rem",
-      top: "0.6rem",
-      bottom: "0.6rem",
-      width: "2px",
-      borderRadius: "999px",
-      background: vars.color.brand,
-    },
   },
 })
 

--- a/packages/ardo/src/ui/theme/reset.css.ts
+++ b/packages/ardo/src/ui/theme/reset.css.ts
@@ -16,6 +16,7 @@ globalStyle("html", {
 })
 
 globalStyle("body", {
+  margin: 0,
   fontFamily: vars.font.family,
   fontSize: vars.font.size,
   lineHeight: vars.font.lineHeight,


### PR DESCRIPTION
## Description

Follow-up to #270. Two layout problems surfaced on the built homepage and docs shell after the visual refinement landed:

1. **8px inset / header overhang.** The `body` element never had its default `8px` user-agent margin reset. Flowing content therefore sat 8px inset on every side, while the `position: fixed` header spans the full viewport width. The result: the header overhangs the content on the right (a visible seam under the header), and every full-width homepage section rule stops ~8px short of the window edges. **Fix:** add `margin: 0` to the body reset so content is full-bleed and aligns with the header.
2. **Orphaned sidebar rail indicator.** The rail's active `::before` bar was anchored to the rail's left edge (`left: -0.75rem`). When the rail background was made transparent in #270, the bar lost its anchoring column and rendered as a stray vertical line floating away from the active icon. **Fix:** remove it — the active state already reads clearly as a neutral pill with a brand-colored icon.

## Motivation and Context

Reported against the newly built homepage: a floating bar next to the sidebar rail icon, a seam under the top-right of the header, and section divider lines not reaching the page edges. Both root causes were confirmed by measuring the rendered DOM (`body { margin: 8px }`; fixed header at `0–1440` vs content inset to `8–1432`).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm format` and `pnpm lint`
- [ ] I have added tests that prove my fix/feature works (if applicable) — visual/layout CSS; verified by measuring the rendered DOM and screenshots in light + dark
- [ ] I have updated the documentation (if applicable) — n/a
- [x] All existing tests pass (`pnpm test`) — 143 unit tests pass; `pnpm docs:build` succeeds
- [x] TypeScript compiles without errors (`pnpm typecheck`)

## Screenshots

Verified before/after in light and dark by rendering the docs site:
- **Body margin:** measured `8px` → `0`; first homepage section `left: 8, width: 1424` → `left: 0, width: 1440` (full-bleed, aligns with the fixed header; no dark-mode frame).
- **Rail:** the stray `|` bar beside the active rail icon is gone; active state is the clean neutral pill + brand icon.

## Additional Notes

Both changes are token/reset-level and low-risk. `body { overflow-x: hidden }` is already set, so removing the margin introduces no horizontal scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWPohB6tJBumo2YHBz8HTL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWPohB6tJBumo2YHBz8HTL)_