### PR TITLE
fix: reset default list padding/margin on sidebar, TOC, rail, and search

### DIFF
--- a/packages/ardo/src/ui/Sidebar.css.ts
+++ b/packages/ardo/src/ui/Sidebar.css.ts
@@ -58,6 +58,8 @@ export const sidebarRailList = style({
   flexDirection: "column",
   alignItems: "center",
   gap: vars.space.xs,
+  margin: 0,
+  padding: 0,
   listStyle: "none",
 })
 
@@ -105,6 +107,8 @@ export const sidebarNav = style({
 })
 
 export const sidebarList = style({
+  margin: 0,
+  padding: 0,
   listStyle: "none",
 })
 

--- a/packages/ardo/src/ui/Toc.css.ts
+++ b/packages/ardo/src/ui/Toc.css.ts
@@ -16,6 +16,8 @@ export const tocTitle = style({
 })
 
 export const tocList = style({
+  margin: 0,
+  padding: 0,
   listStyle: "none",
 })
 

--- a/packages/ardo/src/ui/components/Search.css.ts
+++ b/packages/ardo/src/ui/components/Search.css.ts
@@ -63,6 +63,8 @@ export const searchPopover = style({
 })
 
 export const searchResults = style({
+  margin: 0,
+  padding: 0,
   listStyle: "none",
   maxHeight: "25rem",
   overflowY: "auto",


### PR DESCRIPTION
## Description

Follow-up to #270 / #271. The chrome navigation lists set `list-style: none` but never reset the browser's default `<ul>`/`<ol>` box model, so they inherited `padding-inline-start: 40px` and `margin-block: 16px`. Confirmed by measuring the rendered DOM:

| List | before | after |
|---|---|---|
| Sidebar nav (`sidebarList`) | `padding-inline-start: 40px`, `margin-block: 16px` | `0` |
| Icon rail (`sidebarRailList`) | `40px` / `16px` | `0` |
| Table of contents (`tocList`) | `40px` / `16px` | `0` |
| Search results (`searchResults`) | `40px` / `16px` | `0` |

**Symptoms:** the "On this page" TOC was indented ~40px too far right, the sidebar links sat off their intended alignment (with stray marks clipping at the far-left edge), and the lists added unwanted vertical margins.

**Fix:** add `margin: 0; padding: 0` to those four chrome list styles. The explicit nested indents (`sidebarList1`, `tocLink3`/`tocLink4`) are applied on top and still work. `Steps` and the API hierarchy list already reset their padding, so they're unaffected.

Markdown **content** lists are deliberately not touched — authored `<ul>`/`<ol>` in MDX keep their normal bullets and indentation.

## Motivation and Context

Reported on the built docs shell: the TOC was pushed far to the right and the sidebar showed a stray artifact at the left edge — both traced to unreset default list padding.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `pnpm format` and `pnpm lint`
- [ ] I have added tests that prove my fix/feature works (if applicable) — layout CSS; verified by measuring the rendered DOM (`padding-inline-start` 40px → 0 on all four lists) and screenshots
- [ ] I have updated the documentation (if applicable) — n/a
- [x] All existing tests pass (`pnpm test`) — 143 unit tests pass; `pnpm docs:build` succeeds
- [x] TypeScript compiles without errors (`pnpm typecheck`)

## Screenshots

Verified after the fix by rendering `/guide/markdown`:
- **TOC:** now aligns under its "On this page" heading with correct nested levels (was ~40px over-indented).
- **Sidebar:** links sit at the intended alignment; the left-edge artifact is gone; rail icons stay centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FWPohB6tJBumo2YHBz8HTL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWPohB6tJBumo2YHBz8HTL)_