### PR TITLE
fix: apply configured MDX plugins

### DIFF
--- a/packages/ardo/src/vite/mdx-plugin.test.ts
+++ b/packages/ardo/src/vite/mdx-plugin.test.ts
@@ -1,9 +1,17 @@
+import remarkFrontmatter from "remark-frontmatter"
 import { describe, expect, test } from "vitest"
 
 import { createMdxOptions } from "./mdx-plugin"
 
-const remarkUserPlugin = () => (tree: unknown) => tree
-const rehypeUserPlugin = () => (tree: unknown) => tree
+const passthroughPlugin = (tree: unknown) => tree
+
+function remarkUserPlugin() {
+  return passthroughPlugin
+}
+
+function rehypeUserPlugin() {
+  return passthroughPlugin
+}
 
 describe("createMdxOptions", () => {
   test("appends configured user remark and rehype plugins after built-ins", () => {
@@ -14,5 +22,16 @@ describe("createMdxOptions", () => {
 
     expect(options?.remarkPlugins?.at(-1)).toBe(remarkUserPlugin)
     expect(options?.rehypePlugins?.at(-1)).toBe(rehypeUserPlugin)
+    expect(options?.remarkPlugins?.length).toBeGreaterThan(1)
+    expect(options?.remarkPlugins).toContain(remarkFrontmatter)
+    expect(options?.rehypePlugins?.length).toBeGreaterThan(1)
+  })
+
+  test("uses built-in plugins when no markdown config is supplied", () => {
+    const options = createMdxOptions(undefined)
+
+    expect(options?.remarkPlugins?.length).toBeGreaterThan(1)
+    expect(options?.remarkPlugins).toContain(remarkFrontmatter)
+    expect(options?.rehypePlugins?.length).toBeGreaterThan(0)
   })
 })

--- a/packages/ardo/src/vite/mdx-plugin.test.ts
+++ b/packages/ardo/src/vite/mdx-plugin.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest"
+
+import { createMdxOptions } from "./mdx-plugin"
+
+const remarkUserPlugin = () => (tree: unknown) => tree
+const rehypeUserPlugin = () => (tree: unknown) => tree
+
+describe("createMdxOptions", () => {
+  test("appends configured user remark and rehype plugins after built-ins", () => {
+    const options = createMdxOptions({
+      remarkPlugins: [remarkUserPlugin],
+      rehypePlugins: [rehypeUserPlugin],
+    })
+
+    expect(options?.remarkPlugins?.at(-1)).toBe(remarkUserPlugin)
+    expect(options?.rehypePlugins?.at(-1)).toBe(rehypeUserPlugin)
+  })
+})

--- a/packages/ardo/src/vite/mdx-plugin.ts
+++ b/packages/ardo/src/vite/mdx-plugin.ts
@@ -18,6 +18,12 @@ import { ardoLineTransformer, remarkCodeMeta } from "../markdown/shiki"
 import { recmaWrapExport } from "./recma-wrap-export"
 
 export function createMdxPlugin(markdownConfig: ArdoConfig["markdown"]): Plugin {
+  return mdx(createMdxOptions(markdownConfig)) as Plugin
+}
+
+export function createMdxOptions(
+  markdownConfig: ArdoConfig["markdown"]
+): Parameters<typeof mdx>[0] {
   const themeConfig = markdownConfig?.theme ?? defaultMarkdownConfig.theme
   const lineNumbers = markdownConfig?.lineNumbers ?? false
   const shikiOptions = isShikiThemeObject(themeConfig)
@@ -31,7 +37,7 @@ export function createMdxPlugin(markdownConfig: ArdoConfig["markdown"]): Plugin 
         transformers: [ardoLineTransformer({ globalLineNumbers: lineNumbers })],
       }
 
-  return mdx({
+  return {
     include: /\.(md|mdx)$/,
     remarkPlugins: [
       remarkFrontmatter,
@@ -45,11 +51,12 @@ export function createMdxPlugin(markdownConfig: ArdoConfig["markdown"]): Plugin 
         remarkMdxToc,
         { anchor: markdownConfig?.anchor, levels: markdownConfig?.toc?.level ?? [2, 3] },
       ],
+      ...(markdownConfig?.remarkPlugins ?? []),
     ],
-    rehypePlugins: [[rehypeShiki, shikiOptions]],
+    rehypePlugins: [[rehypeShiki, shikiOptions], ...(markdownConfig?.rehypePlugins ?? [])],
     recmaPlugins: [recmaWrapExport],
     providerImportSource: "ardo/mdx-provider",
-  }) as Plugin
+  }
 }
 
 export function getReactRouterPlugins(): Plugin[] {


### PR DESCRIPTION
## Summary

- forward configured `markdown.remarkPlugins` and `markdown.rehypePlugins` into the MDX route compiler
- keep built-in Ardo plugins first, then append user plugins to match the standalone markdown pipeline behavior
- add unit coverage for the MDX option construction

Closes #203.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vitest --run --config vitest.config.ts packages/ardo/src/vite/mdx-plugin.test.ts`
- `corepack pnpm --filter ardo typecheck`
- `corepack pnpm exec prettier --check packages/ardo/src/vite/mdx-plugin.ts packages/ardo/src/vite/mdx-plugin.test.ts`
- `corepack pnpm lint` (passes with existing warnings)
- `corepack pnpm --filter ardo build`
- `corepack pnpm test`
