### PR TITLE
test: cover typedoc route ordering

### DIFF
--- a/packages/ardo/src/vite/typedoc-routes-order.test.ts
+++ b/packages/ardo/src/vite/typedoc-routes-order.test.ts
@@ -5,6 +5,8 @@ import os from "node:os"
 import path from "node:path"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import type { GeneratedApiDoc } from "../typedoc/types"
+
 import { ardoPlugin } from "./plugin"
 
 vi.mock("../typedoc/generator", async () => {
@@ -17,7 +19,14 @@ vi.mock("../typedoc/generator", async () => {
       await nodeFs.mkdir(nodePath.join(apiDir, "functions"), { recursive: true })
       await nodeFs.writeFile(nodePath.join(apiDir, "index.md"), "# API\n", "utf8")
       await nodeFs.writeFile(nodePath.join(apiDir, "functions", "read.md"), "# read\n", "utf8")
-      return [{ title: "API" }, { title: "read" }]
+      return [
+        { path: "index.md", content: "# API\n", frontmatter: { title: "API" } },
+        {
+          path: "functions/read.md",
+          content: "# read\n",
+          frontmatter: { title: "read" },
+        },
+      ] satisfies GeneratedApiDoc[]
     }),
   }
 })
@@ -54,7 +63,10 @@ describe("TypeDoc route generation order", () => {
     expect(typedocPluginIndex).toBeLessThan(routesPluginIndex)
     expect(routesPluginIndex).toBeLessThan(reactRouterPluginIndex)
 
-    await runConfigHooks(plugins.slice(0, routesPluginIndex + 1), { root: tempDir })
+    const messages = await runConfigHooks(plugins.slice(0, routesPluginIndex + 1), {
+      root: tempDir,
+    })
+    expect(messages).toStrictEqual([])
 
     const routesFile = await fs.readFile(path.join(tempDir, "app", "routes.ts"), "utf8")
     expect(routesFile).toContain('route("api-reference", "routes/api-reference/index.md"),')
@@ -76,7 +88,7 @@ function pluginNameIndex(plugins: Plugin[], namePart: string): number {
   return index
 }
 
-async function runConfigHooks(plugins: Plugin[], userConfig: UserConfig): Promise<void> {
+async function runConfigHooks(plugins: Plugin[], userConfig: UserConfig): Promise<unknown[]> {
   const messages: unknown[] = []
   const context: ConfigPluginContext = {
     debug(message) {
@@ -102,10 +114,25 @@ async function runConfigHooks(plugins: Plugin[], userConfig: UserConfig): Promis
   }
 
   for (const plugin of plugins) {
-    if (typeof plugin.config === "function") {
-      await plugin.config.call(context, userConfig, env)
+    const configHook = getConfigHook(plugin)
+    if (configHook != null) {
+      await configHook.call(context, userConfig, env)
     }
   }
 
-  expect(messages).toStrictEqual([])
+  return messages
 }
+
+function getConfigHook(plugin: Plugin): PluginConfigHook | undefined {
+  if (plugin.config == null) {
+    return undefined
+  }
+
+  if (typeof plugin.config === "function") {
+    return plugin.config
+  }
+
+  return plugin.config.handler
+}
+
+type PluginConfigHook = Exclude<Plugin["config"], { handler: unknown } | undefined>

--- a/packages/ardo/src/vite/typedoc-routes-order.test.ts
+++ b/packages/ardo/src/vite/typedoc-routes-order.test.ts
@@ -1,0 +1,111 @@
+import type { ConfigEnv, ConfigPluginContext, Plugin, UserConfig } from "vite"
+
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ardoPlugin } from "./plugin"
+
+vi.mock("../typedoc/generator", async () => {
+  const nodeFs = await import("node:fs/promises")
+  const nodePath = await import("node:path")
+
+  return {
+    generateApiDocs: vi.fn(async (_typedocConfig: unknown, routesDir: string) => {
+      const apiDir = nodePath.join(routesDir, "api-reference")
+      await nodeFs.mkdir(nodePath.join(apiDir, "functions"), { recursive: true })
+      await nodeFs.writeFile(nodePath.join(apiDir, "index.md"), "# API\n", "utf8")
+      await nodeFs.writeFile(nodePath.join(apiDir, "functions", "read.md"), "# read\n", "utf8")
+      return [{ title: "API" }, { title: "read" }]
+    }),
+  }
+})
+
+let tempDir: string
+
+beforeEach(async () => {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "ardo-typedoc-routes-"))
+  await fs.mkdir(path.join(tempDir, "app", "routes"), { recursive: true })
+  await fs.writeFile(
+    path.join(tempDir, "app", "routes", "home.tsx"),
+    "export default function Home() { return null }\n",
+    "utf8"
+  )
+})
+
+afterEach(async () => {
+  await fs.rm(tempDir, { force: true, recursive: true })
+})
+
+describe("TypeDoc route generation order", () => {
+  it("generates TypeDoc markdown before route config is scanned", async () => {
+    const plugins = ardoPlugin({
+      githubPages: false,
+      typedoc: {
+        entryPoints: ["./src/index.ts"],
+        tsconfig: "./tsconfig.json",
+      },
+    })
+
+    const typedocPluginIndex = pluginIndex(plugins, "ardo:typedoc")
+    const routesPluginIndex = pluginIndex(plugins, "ardo:routes")
+    const reactRouterPluginIndex = pluginNameIndex(plugins, "react-router")
+    expect(typedocPluginIndex).toBeLessThan(routesPluginIndex)
+    expect(routesPluginIndex).toBeLessThan(reactRouterPluginIndex)
+
+    await runConfigHooks(plugins.slice(0, routesPluginIndex + 1), { root: tempDir })
+
+    const routesFile = await fs.readFile(path.join(tempDir, "app", "routes.ts"), "utf8")
+    expect(routesFile).toContain('route("api-reference", "routes/api-reference/index.md"),')
+    expect(routesFile).toContain(
+      'route("api-reference/functions/read", "routes/api-reference/functions/read.md"),'
+    )
+  })
+})
+
+function pluginIndex(plugins: Plugin[], name: string): number {
+  const index = plugins.findIndex((plugin) => plugin.name === name)
+  expect(index).toBeGreaterThanOrEqual(0)
+  return index
+}
+
+function pluginNameIndex(plugins: Plugin[], namePart: string): number {
+  const index = plugins.findIndex((plugin) => plugin.name.includes(namePart))
+  expect(index).toBeGreaterThanOrEqual(0)
+  return index
+}
+
+async function runConfigHooks(plugins: Plugin[], userConfig: UserConfig): Promise<void> {
+  const messages: unknown[] = []
+  const context: ConfigPluginContext = {
+    debug(message) {
+      messages.push(message)
+    },
+    error(error) {
+      const message = typeof error === "string" ? error : error.message
+      throw new Error(message)
+    },
+    info(message) {
+      messages.push(message)
+    },
+    meta: { rolldownVersion: "0.0.0", rollupVersion: "0.0.0", viteVersion: "0.0.0" },
+    warn(message) {
+      messages.push(message)
+    },
+  }
+  const env: ConfigEnv = {
+    command: "build",
+    mode: "production",
+    isPreview: false,
+    isSsrBuild: false,
+  }
+
+  for (const plugin of plugins) {
+    if (typeof plugin.config === "function") {
+      await plugin.config.call(context, userConfig, env)
+    }
+  }
+
+  expect(messages).toStrictEqual([])
+}


### PR DESCRIPTION
## Summary

- add a focused regression test for the TypeDoc and route-generation ordering behind #275
- mock TypeDoc output in a clean temporary routes directory and run Ardo config hooks through ardo:routes
- assert generated api-reference markdown is present in app/routes.ts before React Router plugins run

Closes #275

## Validation

- CI=true pnpm exec vitest --run --config vitest.config.ts packages/ardo/src/vite/typedoc-routes-order.test.ts
- CI=true pnpm exec vitest --run --config vitest.config.ts packages/ardo/src/vite/plugin.test.ts packages/ardo/src/vite/typedoc-routes-order.test.ts packages/ardo/src/vite/routes-core.test.ts
- CI=true pnpm typecheck
- CI=true pnpm build
- CI=true pnpm exec vitest --run --config vitest.integration.config.ts packages/create-ardo/src/scaffold.integration.test.ts
- CI=true pnpm lint