### PR TITLE
fix: mark linked sidebar parent active only on its own page

### DIFF
--- a/packages/ardo/src/ui/Sidebar.test.tsx
+++ b/packages/ardo/src/ui/Sidebar.test.tsx
@@ -7,9 +7,9 @@ import type { SidebarItem } from "../config/types"
 import { ArdoProvider } from "../runtime/hooks"
 import { ArdoSidebar } from "./Sidebar"
 
-function renderSidebar(items: SidebarItem[]): string {
+function renderSidebar(items: SidebarItem[], currentPath = "/"): string {
   return renderToStaticMarkup(
-    <MemoryRouter initialEntries={["/"]}>
+    <MemoryRouter initialEntries={[currentPath]}>
       <ArdoProvider config={{ title: "Docs" }} sidebar={[]}>
         <ArdoSidebar items={items} />
       </ArdoProvider>
@@ -48,5 +48,25 @@ describe("ArdoSidebar", () => {
     expect(view.match(/<button/g)).toHaveLength(1)
     expect(view).toContain('aria-expanded="true"')
     expect(view).toContain('aria-label="Collapse API"')
+  })
+
+  it("marks a linked parent as active only on its own page", () => {
+    const items: SidebarItem[] = [
+      {
+        text: "Architecture Decision Records",
+        link: "/adr",
+        items: [{ text: "ADR-0003", link: "/adr/0003-bitmask-hashing" }],
+      },
+    ]
+
+    const parentLinkClass = (view: string) =>
+      /<a [^>]*class="([^"]*sidebarLink[^"]*)"[^>]*href="\/adr"/.exec(view)?.[1] ?? ""
+
+    const onOverview = parentLinkClass(renderSidebar(items, "/adr"))
+    expect(onOverview.split(/\s+/)).toContain("active")
+
+    const onChild = parentLinkClass(renderSidebar(items, "/adr/0003-bitmask-hashing"))
+    expect(onChild).toContain("child-active")
+    expect(onChild.split(/\s+/)).not.toContain("active")
   })
 })

--- a/packages/ardo/src/ui/Sidebar.test.tsx
+++ b/packages/ardo/src/ui/Sidebar.test.tsx
@@ -59,8 +59,15 @@ describe("ArdoSidebar", () => {
       },
     ]
 
-    const parentLinkClass = (view: string) =>
-      /<a [^>]*class="([^"]*sidebarLink[^"]*)"[^>]*href="\/adr"/.exec(view)?.[1] ?? ""
+    // Locate the panel link to `/adr` regardless of attribute order (React
+    // Router may serialize `href` before or after the computed `class`), then
+    // read its class list. Filtering on `sidebarLink` skips the rail link.
+    const parentLinkClass = (view: string) => {
+      const anchor = (view.match(/<a [^>]*>/g) ?? []).find(
+        (tag) => tag.includes('href="/adr"') && tag.includes("sidebarLink")
+      )
+      return /class="([^"]*)"/.exec(anchor ?? "")?.[1] ?? ""
+    }
 
     const onOverview = parentLinkClass(renderSidebar(items, "/adr"))
     expect(onOverview.split(/\s+/)).toContain("active")

--- a/packages/ardo/src/ui/Sidebar.tsx
+++ b/packages/ardo/src/ui/Sidebar.tsx
@@ -369,6 +369,7 @@ function SidebarItemComponent({ item, depth }: SidebarItemComponentProps) {
         {hasItemLink ? (
           <NavLink
             to={item.link ?? "/"}
+            end={hasChildren}
             className={({ isActive }) =>
               [linkClassName, isActive && "active"].filter(Boolean).join(" ")
             }


### PR DESCRIPTION
## Problem

In generated sidebars, parent items that also have their own `link` were highlighted as fully active on all of their child pages. Visiting a child like `/adr/0003-bitmask-hashing` made the sidebar show two active-looking entries: the parent `/adr` **and** the concrete child — as if two pages were selected at once.

## Cause

`SidebarItemComponent` rendered linked parents as a `NavLink` **without** `end`, so React Router marked `/adr` active for every nested `/adr/...` URL. The manual-composition path (`ArdoSidebarGroup`) already uses `end` on its link and avoids this.

## Fix

Pass `end={hasChildren}` to the parent `NavLink` in `SidebarItemComponent`. A linked parent with children now:

- gets the full `active` state only on its exact overview page (`/adr`)
- shows the existing `child-active` state (open/child-active look) when a child page is selected, without the full active background

Leaf links keep their previous prefix-free behaviour (consistent with `ArdoSidebarLink`).

## Tests

Added a `Sidebar.test.tsx` case asserting the parent link is `active` on `/adr` and `child-active` (not `active`) on `/adr/0003-bitmask-hashing`.

Closes #277

🤖 Generated with [Claude Code](https://claude.com/claude-code)