### PR TITLE
Fix GitHub Pages prerender output

### DIFF
--- a/docs/app/routes/guide/deployment.mdx
+++ b/docs/app/routes/guide/deployment.mdx
@@ -16,25 +16,25 @@ The build output is located in `build/client/` and can be deployed to any static
 
 Ardo automatically detects your GitHub repository name from the git remote and sets Vite's `base` path for you. No manual `base` configuration is needed in `vite.config.ts`.
 
-For client-side routing to work correctly under the subdirectory (e.g. `https://username.github.io/my-docs/`), add `basename` to your `react-router.config.ts`:
+For client-side routing and prerendered HTML to work correctly under the subdirectory (e.g. `https://username.github.io/my-docs/`), wrap your React Router config with `withArdoGitHubPages()`:
 
 ```ts
 import type { Config } from "@react-router/dev/config"
-import { detectGitHubBasename } from "ardo/vite"
+import { withArdoGitHubPages } from "ardo/vite"
 
-export default {
+const config = {
   ssr: false,
   prerender: true,
-  basename: detectGitHubBasename(),
 } satisfies Config
+
+export default withArdoGitHubPages(config)
 ```
 
-`detectGitHubBasename()` returns `"/repo-name/"` when a GitHub remote is detected, or `undefined` otherwise — so it's safe to leave in place for all environments.
+`withArdoGitHubPages()` detects the repository name from your GitHub remote, sets React Router's `basename`, and registers Ardo's final synchronous flatten step for the React Router CLI build.
 
 <Tip>
-  The build output is automatically flattened by Ardo. When `basename` creates nested directories
-  like `build/client/repo-name/`, the plugin moves files back to `build/client/` so GitHub Pages
-  serves them correctly. No post-build script is needed.
+  When React Router writes prerendered files under `build/client/repo-name/`, Ardo moves those files
+  back to `build/client/` after prerendering finishes. No post-build script is needed.
 </Tip>
 
 If you deploy to the root (`https://username.github.io/`), no configuration is needed — both `base` and `basename` will remain at their defaults.

--- a/examples/github-pages/.gitignore
+++ b/examples/github-pages/.gitignore
@@ -1,0 +1,3 @@
+build/
+.react-router/
+node_modules/

--- a/examples/github-pages/app/entry.client.tsx
+++ b/examples/github-pages/app/entry.client.tsx
@@ -1,0 +1,12 @@
+import { startTransition, StrictMode } from "react"
+import { hydrateRoot } from "react-dom/client"
+import { HydratedRouter } from "react-router/dom"
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <HydratedRouter />
+    </StrictMode>
+  )
+})

--- a/examples/github-pages/app/entry.server.tsx
+++ b/examples/github-pages/app/entry.server.tsx
@@ -1,0 +1,34 @@
+import type { EntryContext } from "react-router"
+import { ServerRouter } from "react-router"
+import { renderToReadableStream } from "react-dom/server"
+import { isbot } from "isbot"
+
+export default async function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  routerContext: EntryContext
+) {
+  const userAgent = request.headers.get("user-agent")
+
+  const stream = await renderToReadableStream(
+    <ServerRouter context={routerContext} url={request.url} />,
+    {
+      onError(error: unknown) {
+        console.error(error)
+        responseStatusCode = 500
+      },
+    }
+  )
+
+  if (userAgent && isbot(userAgent)) {
+    await stream.allReady
+  }
+
+  responseHeaders.set("Content-Type", "text/html")
+
+  return new Response(stream, {
+    status: responseStatusCode,
+    headers: responseHeaders,
+  })
+}

--- a/examples/github-pages/app/root.tsx
+++ b/examples/github-pages/app/root.tsx
@@ -1,0 +1,31 @@
+import { ArdoRootLayout, ArdoRoot, ArdoNav, ArdoNavLink } from "ardo/ui"
+import config from "virtual:ardo/config"
+import sidebar from "virtual:ardo/sidebar"
+import type { MetaFunction } from "react-router"
+import "ardo/ui/styles.css"
+import "./theme.css"
+
+export const meta: MetaFunction = () => [{ title: "Ardo Basic Example" }]
+
+export function Layout({ children }: { children: React.ReactNode }) {
+  return <ArdoRootLayout>{children}</ArdoRootLayout>
+}
+
+export default function Root() {
+  return (
+    <ArdoRoot
+      config={config}
+      sidebar={sidebar}
+      headerProps={{
+        nav: (
+          <ArdoNav>
+            <ArdoNavLink to="/guide/getting-started">Guide</ArdoNavLink>
+          </ArdoNav>
+        ),
+      }}
+      footerProps={{
+        message: "Built with Ardo",
+      }}
+    />
+  )
+}

--- a/examples/github-pages/app/routes/guide/getting-started.mdx
+++ b/examples/github-pages/app/routes/guide/getting-started.mdx
@@ -1,0 +1,51 @@
+---
+title: Getting Started
+description: Get up and running with this basic Ardo example.
+order: 1
+---
+
+# Getting Started
+
+Welcome to the **Ardo Basic Example**. This is a minimal documentation site that demonstrates Ardo as a pure static site generator — no TypeDoc, no library code, just Markdown.
+
+## What's Included
+
+This example shows:
+
+- Markdown content with frontmatter
+- Automatic route generation
+- Built-in search
+- Dark mode support
+- Static pre-rendering
+
+## Project Structure
+
+```
+examples/basic/
+├── app/
+│   ├── routes/
+│   │   ├── home.tsx
+│   │   └── guide/
+│   │       ├── getting-started.mdx
+│   │       └── markdown-features.mdx
+│   ├── root.tsx
+│   ├── entry.client.tsx
+│   └── entry.server.tsx
+├── vite.config.ts
+├── react-router.config.ts
+└── package.json
+```
+
+## Running Locally
+
+```bash
+pnpm dev
+```
+
+## Building for Production
+
+```bash
+pnpm build
+```
+
+The output will be in `build/client/`, ready for static hosting on Vercel, Netlify, or any other platform.

--- a/examples/github-pages/app/routes/guide/markdown-features.mdx
+++ b/examples/github-pages/app/routes/guide/markdown-features.mdx
@@ -1,0 +1,50 @@
+---
+title: Markdown Features
+description: Explore the Markdown features available in Ardo.
+order: 2
+---
+
+# Markdown Features
+
+Ardo supports standard Markdown, GitHub Flavored Markdown (GFM), and several extensions.
+
+## Code Blocks
+
+Syntax highlighting is powered by Shiki:
+
+```typescript
+interface User {
+  id: string
+  name: string
+  email: string
+}
+
+function greetUser(user: User): string {
+  return `Hello, ${user.name}!`
+}
+```
+
+## Tables
+
+| Feature         | Supported |
+| --------------- | --------- |
+| GFM Tables      | Yes       |
+| Task Lists      | Yes       |
+| Code Highlights | Yes       |
+| Callouts        | Yes       |
+
+## Task Lists
+
+- [x] Set up project
+- [x] Add Markdown content
+- [ ] Deploy to production
+
+## Callout Components
+
+<Tip>This is a helpful tip for your readers.</Tip>
+
+<Warning>Be careful when using this feature in production.</Warning>
+
+<Danger>This action cannot be undone!</Danger>
+
+<Info>Here is some additional context.</Info>

--- a/examples/github-pages/app/routes/home.tsx
+++ b/examples/github-pages/app/routes/home.tsx
@@ -1,0 +1,28 @@
+import { ArdoHero, ArdoFeatures, ArdoFeatureCard } from "ardo/ui"
+import type { MetaFunction } from "react-router"
+
+export const meta: MetaFunction = () => [{ title: "Ardo GitHub Pages Example" }]
+
+export default function HomePage() {
+  return (
+    <>
+      <ArdoHero
+        name="Ardo GitHub Pages Example"
+        text="Documentation Made Simple"
+        tagline="A GitHub Pages documentation site built with Ardo — no TypeDoc, just Markdown."
+        actions={[{ text: "Get Started", link: "/guide/getting-started", theme: "brand" }]}
+      />
+      <ArdoFeatures>
+        <ArdoFeatureCard title="Markdown" icon="📝">
+          Write documentation in Markdown with full GFM support
+        </ArdoFeatureCard>
+        <ArdoFeatureCard title="Fast" icon="⚡">
+          Lightning fast builds powered by Vite
+        </ArdoFeatureCard>
+        <ArdoFeatureCard title="Search" icon="🔍">
+          Built-in full-text search with MiniSearch
+        </ArdoFeatureCard>
+      </ArdoFeatures>
+    </>
+  )
+}

--- a/examples/github-pages/app/theme.css
+++ b/examples/github-pages/app/theme.css
@@ -1,0 +1,5 @@
+:root {
+  --ardo-brand-h: 250;
+  --ardo-brand-c: 0.14;
+  --ardo-brand-l: 0.48;
+}

--- a/examples/github-pages/build.test.ts
+++ b/examples/github-pages/build.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeAll } from "vitest"
+import fs from "node:fs"
+import path from "node:path"
+import { execSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const buildClientDir = path.join(__dirname, "build", "client")
+
+describe("examples/github-pages build", () => {
+  let buildSucceeded = false
+
+  beforeAll(() => {
+    execSync("npx react-router build", {
+      cwd: __dirname,
+      stdio: "pipe",
+      timeout: 120_000,
+    })
+
+    buildSucceeded = true
+  }, 180_000)
+
+  it("completes build successfully", () => {
+    expect(buildSucceeded).toBe(true)
+  })
+
+  it("flattens prerendered pages to the GitHub Pages artifact root", () => {
+    expect(fs.existsSync(path.join(buildClientDir, "index.html"))).toBe(true)
+    expect(fs.existsSync(path.join(buildClientDir, "guide", "getting-started", "index.html"))).toBe(
+      true
+    )
+    expect(
+      fs.existsSync(path.join(buildClientDir, "guide", "markdown-features", "index.html"))
+    ).toBe(true)
+    expect(fs.existsSync(path.join(buildClientDir, "ardo"))).toBe(false)
+  })
+
+  it("keeps GitHub Pages basename in generated links and asset references", () => {
+    const indexHtml = fs.readFileSync(path.join(buildClientDir, "index.html"), "utf8")
+
+    expect(indexHtml).toContain('href="/ardo/guide/getting-started"')
+    expect(indexHtml).toContain('href="/ardo/assets/')
+    expect(indexHtml).toContain('import "/ardo/assets/')
+    expect(indexHtml).not.toContain('href="/assets/')
+    expect(indexHtml).not.toContain('import "/assets/')
+  })
+})

--- a/examples/github-pages/package.json
+++ b/examples/github-pages/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ardo-example-github-pages",
+  "private": true,
+  "type": "module",
+  "homepage": "https://github.com/sebastian-software/ardo/tree/main/examples/github-pages",
+  "author": "Sebastian Software GmbH",
+  "scripts": {
+    "dev": "react-router dev",
+    "build": "react-router build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "ardo": "workspace:*",
+    "isbot": "^5.1.40",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router": "^8.0.1"
+  },
+  "devDependencies": {
+    "@react-router/dev": "^8.0.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/examples/github-pages/react-router.config.ts
+++ b/examples/github-pages/react-router.config.ts
@@ -1,9 +1,9 @@
 import type { Config } from "@react-router/dev/config"
-{{GITHUB_PAGES_REACT_ROUTER_IMPORT}}
+import { withArdoGitHubPages } from "ardo/vite"
 
 const config = {
   ssr: false,
   prerender: true,
 } satisfies Config
 
-export default {{GITHUB_PAGES_REACT_ROUTER_CONFIG}}
+export default withArdoGitHubPages(config, { basename: "/ardo/" })

--- a/examples/github-pages/tsconfig.json
+++ b/examples/github-pages/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "ardo/virtual"]
+  },
+  "include": ["app/**/*", "*.ts", "*.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/github-pages/vite.config.ts
+++ b/examples/github-pages/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite"
+import { ardo } from "ardo/vite"
+
+export default defineConfig({
+  base: "/ardo/",
+  plugins: [
+    ardo({
+      title: "Ardo GitHub Pages Example",
+      description: "A GitHub Pages documentation site built with Ardo",
+      githubPages: false,
+    }),
+  ],
+})

--- a/packages/ardo/src/vite/flatten-plugin.test.ts
+++ b/packages/ardo/src/vite/flatten-plugin.test.ts
@@ -10,6 +10,7 @@ import { flattenGitHubPagesBuildOutput, withArdoGitHubPages } from "./flatten-pl
 
 type BuildEnd = NonNullable<Config["buildEnd"]>
 type BuildEndArgs = Parameters<BuildEnd>[0]
+type ExitListener = (code: number) => void
 
 describe("flattenGitHubPagesBuildOutput", () => {
   it("flattens from the resolved React Router client build directory", async () => {
@@ -37,6 +38,11 @@ describe("flattenGitHubPagesBuildOutput", () => {
 describe("withArdoGitHubPages", () => {
   it("sets the GitHub Pages basename and flattens after an existing buildEnd hook", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "ardo-build-end-"))
+    let exitListener: ExitListener | undefined
+    const processOnce = captureProcessExitListener((listener) => {
+      exitListener = listener
+    })
+
     try {
       const root = path.join(tmpDir, "project")
       const buildDir = path.join(root, "build", "client")
@@ -62,18 +68,87 @@ describe("withArdoGitHubPages", () => {
       await expect(readFile(path.join(buildDir, "repo", "index.html"), "utf8")).resolves.toBe(
         "nested"
       )
+      expect(processOnce).toHaveBeenCalledWith("exit", expect.any(Function))
+      expect(exitListener).toBeDefined()
 
-      process.emit("exit", 0)
+      exitListener?.(0)
 
       await expect(readFile(path.join(buildDir, "index.html"), "utf8")).resolves.toBe("nested")
       await expect(readFile(path.join(buildDir, "repo", "index.html"), "utf8")).rejects.toThrow(
         "ENOENT"
       )
     } finally {
+      processOnce.mockRestore()
+      await rm(tmpDir, { force: true, recursive: true })
+    }
+  })
+
+  it("lets the explicit options basename override the wrapped config basename", () => {
+    const config = withArdoGitHubPages(
+      {
+        basename: "/old/",
+        ssr: false,
+      },
+      { basename: "/new/" }
+    )
+
+    expect(config.basename).toBe("/new/")
+  })
+
+  it("marks the process as failed when deferred flattening throws", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "ardo-build-end-failure-"))
+    let exitListener: ExitListener | undefined
+    const previousExitCode = process.exitCode
+    const processOnce = captureProcessExitListener((listener) => {
+      exitListener = listener
+    })
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    try {
+      process.exitCode = undefined
+      const root = path.join(tmpDir, "project")
+      const buildDir = path.join(root, "build", "client")
+      await mkdir(buildDir, { recursive: true })
+      await writeFile(path.join(buildDir, "repo"), "not a directory", "utf8")
+
+      const config = withArdoGitHubPages(
+        {
+          ssr: false,
+        },
+        { basename: "/repo/" }
+      )
+
+      await config.buildEnd(
+        await createBuildEndArgs({ basename: "/repo/", buildDirectory: "build", root })
+      )
+
+      expect(exitListener).toBeDefined()
+      exitListener?.(0)
+
+      expect(process.exitCode).toBe(1)
+      expect(consoleError).toHaveBeenCalledWith(
+        "[ardo] Failed to flatten GitHub Pages build output."
+      )
+    } finally {
+      process.exitCode = previousExitCode
+      consoleError.mockRestore()
+      processOnce.mockRestore()
       await rm(tmpDir, { force: true, recursive: true })
     }
   })
 })
+
+function captureProcessExitListener(onListener: (listener: ExitListener) => void) {
+  const mockOnce = (event: string | symbol, listener: (...args: unknown[]) => void) => {
+    expect(event).toBe("exit")
+    onListener((code) => {
+      listener(code)
+    })
+    return process
+  }
+
+  return vi.spyOn(process, "once").mockImplementation(mockOnce as typeof process.once)
+}
 
 async function createBuildEndArgs(input: {
   basename: string

--- a/packages/ardo/src/vite/flatten-plugin.test.ts
+++ b/packages/ardo/src/vite/flatten-plugin.test.ts
@@ -1,46 +1,108 @@
-import type { Plugin } from "vite"
+import type { Config } from "@react-router/dev/config"
 
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { describe, expect, it } from "vitest"
+import { resolveConfig } from "vite"
+import { describe, expect, it, vi } from "vitest"
 
-import { createFlattenPlugin } from "./flatten-plugin"
+import { flattenGitHubPagesBuildOutput, withArdoGitHubPages } from "./flatten-plugin"
 
-type FlattenPluginHooks = {
-  closeBundle: () => Promise<void> | void
-  configResolved: (config: { base: string; build: { outDir: string }; root: string }) => void
-}
+type BuildEnd = NonNullable<Config["buildEnd"]>
+type BuildEndArgs = Parameters<BuildEnd>[0]
 
-describe("createFlattenPlugin", () => {
-  it("flattens from the resolved build output directory per plugin instance", async () => {
+describe("flattenGitHubPagesBuildOutput", () => {
+  it("flattens from the resolved React Router client build directory", async () => {
     const tmpDir = await mkdtemp(path.join(os.tmpdir(), "ardo-flatten-"))
     try {
       const root = path.join(tmpDir, "project")
-      const buildDir = path.join(root, "custom-client")
+      const buildDir = path.join(root, "custom-build", "client")
       await mkdir(path.join(buildDir, "docs"), { recursive: true })
       await writeFile(path.join(buildDir, "docs", "index.html"), "nested", "utf8")
 
-      const plugin = createFlattenPlugin()
-      if (!hasFlattenPluginHooks(plugin)) {
-        throw new Error("Flatten plugin hooks not found")
-      }
-
-      plugin.configResolved({
-        base: "/docs/",
-        build: { outDir: "custom-client" },
-        root,
-      })
-
-      await plugin.closeBundle()
+      flattenGitHubPagesBuildOutput(
+        await createBuildEndArgs({ basename: "/docs/", buildDirectory: "custom-build", root })
+      )
 
       await expect(readFile(path.join(buildDir, "index.html"), "utf8")).resolves.toBe("nested")
+      await expect(readFile(path.join(buildDir, "docs", "index.html"), "utf8")).rejects.toThrow(
+        "ENOENT"
+      )
     } finally {
       await rm(tmpDir, { force: true, recursive: true })
     }
   })
 })
 
-function hasFlattenPluginHooks(plugin: Plugin): plugin is FlattenPluginHooks & Plugin {
-  return typeof plugin.configResolved === "function" && typeof plugin.closeBundle === "function"
+describe("withArdoGitHubPages", () => {
+  it("sets the GitHub Pages basename and flattens after an existing buildEnd hook", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "ardo-build-end-"))
+    try {
+      const root = path.join(tmpDir, "project")
+      const buildDir = path.join(root, "build", "client")
+      await mkdir(path.join(buildDir, "repo"), { recursive: true })
+      await writeFile(path.join(buildDir, "repo", "index.html"), "nested", "utf8")
+      const userBuildEnd = vi.fn<BuildEnd>()
+
+      const config = withArdoGitHubPages(
+        {
+          ssr: false,
+          prerender: true,
+          buildEnd: userBuildEnd,
+        },
+        { basename: "/repo/" }
+      )
+
+      expect(config.basename).toBe("/repo/")
+
+      const args = await createBuildEndArgs({ basename: "/repo/", buildDirectory: "build", root })
+      await config.buildEnd(args)
+
+      expect(userBuildEnd).toHaveBeenCalledWith(args)
+      await expect(readFile(path.join(buildDir, "repo", "index.html"), "utf8")).resolves.toBe(
+        "nested"
+      )
+
+      process.emit("exit", 0)
+
+      await expect(readFile(path.join(buildDir, "index.html"), "utf8")).resolves.toBe("nested")
+      await expect(readFile(path.join(buildDir, "repo", "index.html"), "utf8")).rejects.toThrow(
+        "ENOENT"
+      )
+    } finally {
+      await rm(tmpDir, { force: true, recursive: true })
+    }
+  })
+})
+
+async function createBuildEndArgs(input: {
+  basename: string
+  buildDirectory: string
+  root: string
+}): Promise<BuildEndArgs> {
+  return {
+    buildManifest: undefined,
+    reactRouterConfig: {
+      allowedActionOrigins: false,
+      appDirectory: path.join(input.root, "app"),
+      basename: input.basename,
+      buildDirectory: input.buildDirectory,
+      future: {
+        unstable_optimizeDeps: false,
+      },
+      prerender: true,
+      routeDiscovery: {
+        mode: "lazy",
+        manifestPath: "/__manifest",
+      },
+      routes: {},
+      serverBuildFile: "index.js",
+      serverModuleFormat: "esm",
+      splitRouteModules: true,
+      ssr: false,
+      subResourceIntegrity: false,
+      unstable_routeConfig: [],
+    },
+    viteConfig: await resolveConfig({ root: input.root }, "build"),
+  }
 }

--- a/packages/ardo/src/vite/flatten-plugin.ts
+++ b/packages/ardo/src/vite/flatten-plugin.ts
@@ -22,7 +22,7 @@ export function withArdoGitHubPages<TConfig extends Config>(
   options: ArdoGitHubPagesOptions = {}
 ): Required<Pick<Config, "basename" | "buildEnd">> & TConfig {
   const userBuildEnd = config.buildEnd
-  const basename = config.basename ?? options.basename ?? detectGitHubBasename(options.cwd)
+  const basename = options.basename ?? config.basename ?? detectGitHubBasename(options.cwd)
   const buildEnd: BuildEnd = async (args) => {
     await userBuildEnd?.(args)
     scheduleGitHubPagesBuildOutputFlatten(args)
@@ -39,7 +39,13 @@ export function scheduleGitHubPagesBuildOutputFlatten(args: GitHubPagesBuildArgs
   // React Router calls buildEnd before prerendering; the CLI exit event is the first reliable
   // synchronous point after pre-rendered HTML has been written.
   process.once("exit", () => {
-    flattenGitHubPagesBuildOutput(args)
+    try {
+      flattenGitHubPagesBuildOutput(args)
+    } catch (error) {
+      process.exitCode = 1
+      console.error("[ardo] Failed to flatten GitHub Pages build output.")
+      console.error(error)
+    }
   })
 }
 

--- a/packages/ardo/src/vite/flatten-plugin.ts
+++ b/packages/ardo/src/vite/flatten-plugin.ts
@@ -1,44 +1,68 @@
-import type { Plugin } from "vite"
+import type { Config } from "@react-router/dev/config"
 
 import fs from "node:fs"
 import path from "node:path"
 
-import { copyRecursive } from "./git-utils"
+import { copyRecursive, detectGitHubBasename } from "./git-utils"
 
-export function createFlattenPlugin(): Plugin {
-  let detectedBase: string | undefined
-  let buildDir = path.resolve(process.cwd(), "build", "client")
-  let flattenExecuted = false
+type BuildEnd = NonNullable<Config["buildEnd"]>
+type BuildEndArgs = Parameters<BuildEnd>[0]
+type GitHubPagesBuildArgs = {
+  reactRouterConfig: Pick<BuildEndArgs["reactRouterConfig"], "basename" | "buildDirectory">
+  viteConfig: Pick<BuildEndArgs["viteConfig"], "root">
+}
+
+export type ArdoGitHubPagesOptions = {
+  basename?: string
+  cwd?: string
+}
+
+export function withArdoGitHubPages<TConfig extends Config>(
+  config: TConfig,
+  options: ArdoGitHubPagesOptions = {}
+): Required<Pick<Config, "basename" | "buildEnd">> & TConfig {
+  const userBuildEnd = config.buildEnd
+  const basename = config.basename ?? options.basename ?? detectGitHubBasename(options.cwd)
+  const buildEnd: BuildEnd = async (args) => {
+    await userBuildEnd?.(args)
+    scheduleGitHubPagesBuildOutputFlatten(args)
+  }
 
   return {
-    name: "ardo:flatten-github-pages",
-    enforce: "post",
-    configResolved(config) {
-      detectedBase = config.base === "/" ? undefined : config.base
-      buildDir = path.resolve(config.root, config.build.outDir)
-    },
-    closeBundle() {
-      if (flattenExecuted || detectedBase == null) {
-        return
-      }
-
-      const baseName = trimSlashes(detectedBase)
-      if (baseName === "") {
-        return
-      }
-
-      const nestedDir = path.join(buildDir, baseName)
-      if (!fs.existsSync(nestedDir)) {
-        return
-      }
-
-      console.log(`[ardo] Flattening ${path.relative(process.cwd(), nestedDir)} for GitHub Pages`)
-      copyRecursive(nestedDir, buildDir)
-      fs.rmSync(nestedDir, { recursive: true, force: true })
-      console.log("[ardo] Build output flattened successfully.")
-      flattenExecuted = true
-    },
+    ...config,
+    basename,
+    buildEnd,
   }
+}
+
+export function scheduleGitHubPagesBuildOutputFlatten(args: GitHubPagesBuildArgs): void {
+  // React Router calls buildEnd before prerendering; the CLI exit event is the first reliable
+  // synchronous point after pre-rendered HTML has been written.
+  process.once("exit", () => {
+    flattenGitHubPagesBuildOutput(args)
+  })
+}
+
+export function flattenGitHubPagesBuildOutput(args: GitHubPagesBuildArgs): void {
+  const baseName = trimSlashes(args.reactRouterConfig.basename)
+  if (baseName === "") {
+    return
+  }
+
+  const buildDir = path.resolve(
+    args.viteConfig.root,
+    args.reactRouterConfig.buildDirectory,
+    "client"
+  )
+  const nestedDir = path.join(buildDir, baseName)
+  if (!fs.existsSync(nestedDir)) {
+    return
+  }
+
+  console.log(`[ardo] Flattening ${path.relative(process.cwd(), nestedDir)} for GitHub Pages`)
+  copyRecursive(nestedDir, buildDir)
+  fs.rmSync(nestedDir, { recursive: true, force: true })
+  console.log("[ardo] Build output flattened successfully.")
 }
 
 function trimSlashes(value: string): string {

--- a/packages/ardo/src/vite/index.ts
+++ b/packages/ardo/src/vite/index.ts
@@ -16,6 +16,11 @@ export {
 } from "../runtime/loader"
 export { generateSidebar, type SidebarGenerationOptions } from "../runtime/sidebar"
 
+export {
+  type ArdoGitHubPagesOptions,
+  flattenGitHubPagesBuildOutput,
+  withArdoGitHubPages,
+} from "./flatten-plugin"
 export { type ArdoIconOptions } from "./icons"
 // Vite Plugin
 export { ardoPlugin as ardo, ardoPlugin, type ArdoPluginOptions } from "./plugin"

--- a/packages/ardo/src/vite/index.ts
+++ b/packages/ardo/src/vite/index.ts
@@ -16,11 +16,7 @@ export {
 } from "../runtime/loader"
 export { generateSidebar, type SidebarGenerationOptions } from "../runtime/sidebar"
 
-export {
-  type ArdoGitHubPagesOptions,
-  flattenGitHubPagesBuildOutput,
-  withArdoGitHubPages,
-} from "./flatten-plugin"
+export { type ArdoGitHubPagesOptions, withArdoGitHubPages } from "./flatten-plugin"
 export { type ArdoIconOptions } from "./icons"
 // Vite Plugin
 export { ardoPlugin as ardo, ardoPlugin, type ArdoPluginOptions } from "./plugin"

--- a/packages/ardo/src/vite/plugin.ts
+++ b/packages/ardo/src/vite/plugin.ts
@@ -11,7 +11,6 @@ import {
   formatLinkCheckDiagnostics,
 } from "./build-outputs"
 import { ardoCodeBlockPlugin } from "./codeblock-plugin"
-import { createFlattenPlugin } from "./flatten-plugin"
 import {
   detectGitHash,
   detectGitHubBasename,
@@ -102,10 +101,6 @@ export function ardoPlugin(options: ArdoPluginOptions = {}): Plugin[] {
   plugins.push(createMdxPlugin(pressConfig.markdown))
   plugins.push(...vanillaExtractPlugin({ identifiers: "short" }))
   plugins.push(...getReactRouterPlugins())
-
-  if (githubPages) {
-    plugins.push(createFlattenPlugin())
-  }
 
   return plugins
 }

--- a/packages/create-ardo/src/scaffold.test.ts
+++ b/packages/create-ardo/src/scaffold.test.ts
@@ -92,6 +92,22 @@ describe("createProjectStructure", () => {
     expect(fs.existsSync(path.join(tmpDir, "pnpm-workspace.yaml"))).toBe(false)
   })
 
+  it("wraps React Router config for GitHub Pages prerender output", () => {
+    createProjectStructure(tmpDir, "minimal", {
+      siteTitle: "Docs",
+      projectName: "docs-site",
+      typedoc: false,
+      githubPages: true,
+      description: "Built with Ardo",
+    })
+
+    const reactRouterConfig = fs.readFileSync(path.join(tmpDir, "react-router.config.ts"), "utf8")
+
+    expect(reactRouterConfig).toContain(`import { withArdoGitHubPages } from "ardo/vite"`)
+    expect(reactRouterConfig).toContain("export default withArdoGitHubPages(config)")
+    expect(reactRouterConfig).not.toContain("detectGitHubBasename")
+  })
+
   it("keeps only the working pnpm build-script allowlist for pnpm scaffolds", () => {
     createProjectStructure(tmpDir, "minimal", {
       siteTitle: "Docs",

--- a/packages/create-ardo/src/scaffold.ts
+++ b/packages/create-ardo/src/scaffold.ts
@@ -63,12 +63,12 @@ export function createProjectStructure(root: string, template: string, options: 
     GITHUB_PAGES_CONFIG: options.githubPages
       ? "// GitHub Pages: base path auto-detected from git remote"
       : "githubPages: false, // Disabled for non-GitHub Pages deployment",
-    GITHUB_PAGES_BASENAME_IMPORT: options.githubPages
-      ? 'import { detectGitHubBasename } from "ardo/vite"'
+    GITHUB_PAGES_REACT_ROUTER_IMPORT: options.githubPages
+      ? 'import { withArdoGitHubPages } from "ardo/vite"'
       : "",
-    GITHUB_PAGES_BASENAME: options.githubPages
-      ? "basename: detectGitHubBasename(),"
-      : "// basename: detectGitHubBasename(), // Uncomment for GitHub Pages",
+    GITHUB_PAGES_REACT_ROUTER_CONFIG: options.githubPages
+      ? "withArdoGitHubPages(config)"
+      : "config",
     DESCRIPTION: escapeTemplateValue(options.description),
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,40 @@ importers:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  examples/github-pages:
+    dependencies:
+      ardo:
+        specifier: workspace:*
+        version: link:../../packages/ardo
+      isbot:
+        specifier: ^5.1.40
+        version: 5.1.40
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      react-router:
+        specifier: ^8.0.1
+        version: 8.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    devDependencies:
+      '@react-router/dev':
+        specifier: ^8.0.1
+        version: 8.0.1(react-router@8.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
+
   examples/library:
     dependencies:
       ardo:


### PR DESCRIPTION
Fixes #281.

## Summary
- add withArdoGitHubPages() so React Router config owns the GitHub Pages basename and final output flattening
- move flattening out of the Vite closeBundle phase because React Router writes pre-rendered HTML after buildEnd
- scaffold the GitHub Pages wrapper in create-ardo templates and document the setup
- add examples/github-pages as an end-to-end regression fixture for GitHub Pages builds

## Regression Coverage
- the new example builds with base: "/ardo/" and withArdoGitHubPages(config, { basename: "/ardo/" })
- the integration test runs react-router build and asserts root HTML files exist, the nested basename directory is removed, and emitted links/assets still use the /ardo/ prefix

## Verification
- CI=true pnpm exec vitest --run --config vitest.config.ts packages/ardo/src/vite/flatten-plugin.test.ts packages/create-ardo/src/scaffold.test.ts
- CI=true pnpm exec vitest --run --config vitest.integration.config.ts examples/github-pages/build.test.ts
- CI=true pnpm --filter ardo typecheck
- CI=true pnpm --filter create-ardo typecheck
- CI=true pnpm --filter ardo-example-github-pages exec tsc --noEmit
- CI=true pnpm exec prettier --check docs/app/routes/guide/deployment.mdx packages/ardo/src/vite/flatten-plugin.ts packages/ardo/src/vite/flatten-plugin.test.ts packages/ardo/src/vite/index.ts packages/ardo/src/vite/plugin.ts packages/create-ardo/src/scaffold.ts packages/create-ardo/src/scaffold.test.ts packages/create-ardo/templates/minimal/react-router.config.ts examples/github-pages
- pre-push: pnpm -r typecheck
- pre-push: eslint packages/*/src