### PR TITLE
feat: add brand shortcut

### DIFF
--- a/docs/app/routes/guide/configuration.mdx
+++ b/docs/app/routes/guide/configuration.mdx
@@ -135,6 +135,32 @@ ardo({
 })
 ```
 
+### brand
+
+- **Type:** `{ color?: number | Preset; accent?: number | Preset; neutral?: number | Preset; logo?: string | { light: string; dark: string } }`
+- **Default:** `{}`
+
+Simple brand configuration for the default theme and header logo. `color`, `accent`, and `neutral`
+accept OKLCH hue numbers or preset names: `berry`, `red`, `orange`, `amber`, `green`, `teal`,
+`blue`, `indigo`, `purple`, `pink`, `slate`, and `gray`.
+
+```ts
+ardo({
+  title: "My Docs",
+  brand: {
+    color: "blue",
+    accent: "teal",
+    neutral: "slate",
+    logo: "./app/assets/logo.svg",
+  },
+})
+```
+
+When `color` is set without `accent`, Ardo derives an accent hue. When `neutral` is omitted, the
+neutral chrome follows `color`. Local SVG logo paths are bundled for the default header and also
+become the default source for generated favicons. Use `headerProps.logo` or `icons.source` when the
+header and favicon should use different assets.
+
 ### seo.llms
 
 - **Type:** `boolean | { indexFileName?: string; fullFileName?: string; includeFull?: boolean; title?: string; description?: string }`

--- a/docs/app/routes/guide/custom-theme.mdx
+++ b/docs/app/routes/guide/custom-theme.mdx
@@ -103,7 +103,7 @@ The default hue is `356` (a muted berry tone). Some starting points:
 | `356` | Berry (default) |
 | `170` | Teal            |
 | `240` | Blue            |
-| `260` | Indigo          |
+| `270` | Indigo          |
 | `290` | Purple          |
 | `330` | Pink            |
 | `25`  | Red             |

--- a/docs/app/routes/guide/custom-theme.mdx
+++ b/docs/app/routes/guide/custom-theme.mdx
@@ -6,20 +6,67 @@ order: 7
 
 # Custom Theme
 
-Ardo starts with a polished default theme, but it is not a black box. React teams should be able to carry their brand, design system, and component choices into documentation without fighting the framework. You have four levels of customization, and you can mix them freely:
+Ardo starts with a polished default theme, but it is not a black box. React teams should be able to carry their brand, design system, and component choices into documentation without fighting the framework. You have five levels of customization, and you can mix them freely:
 
-1. **CSS variables** — Change colors, spacing, and typography without touching components
-2. **Vanilla Extract tokens** — Type-safe styling with `ardo/theme` imports and `.css.ts` files
-3. **Component overrides** — Replace individual pieces (header, sidebar, footer) with your own React components
-4. **Full custom theme** — Build your entire layout from scratch, using Ardo's runtime hooks for data
+1. **Brand shortcut** — Set brand, accent, neutral, and logo values in `ardo()`
+2. **CSS variables** — Change colors, spacing, and typography without touching components
+3. **Vanilla Extract tokens** — Type-safe styling with `ardo/theme` imports and `.css.ts` files
+4. **Component overrides** — Replace individual pieces (header, sidebar, footer) with your own React components
+5. **Full custom theme** — Build your entire layout from scratch, using Ardo's runtime hooks for data
 
 Start simple. Go deeper when you need to.
 
-## Brand Color
+## Brand Shortcut
 
-The fastest way to customize Ardo's look. The default theme uses OKLCH hue tokens for brand, accent,
-and neutral chrome colors, so you can change the brand while keeping backgrounds, borders, header,
-sidebar, and text on a separate neutral base.
+Use `brand` in `vite.config.ts` for the common case: one primary brand color, one accent color, a
+neutral chrome tone, and a logo.
+
+```ts
+import { defineConfig } from "vite"
+import { ardo } from "ardo/vite"
+
+export default defineConfig({
+  plugins: [
+    ardo({
+      title: "Acme Docs",
+      brand: {
+        color: "blue",
+        accent: "teal",
+        neutral: "slate",
+        logo: "./app/assets/logo.svg",
+      },
+    }),
+  ],
+})
+```
+
+`color`, `accent`, and `neutral` accept either preset names or OKLCH hue numbers:
+
+```ts
+ardo({
+  title: "Acme Docs",
+  brand: {
+    color: 240,
+    accent: 170,
+    neutral: 260,
+  },
+})
+```
+
+Presets: `berry`, `red`, `orange`, `amber`, `green`, `teal`, `blue`, `indigo`, `purple`, `pink`,
+`slate`, and `gray`.
+
+When `color` is set without `accent`, Ardo derives a complementary accent. When `neutral` is omitted,
+neutral chrome follows the brand hue. `brand.logo` is used by the default header and, for local SVG
+paths, as the default source for generated favicons. Explicit `headerProps.logo` and
+`icons.source` still win when you need different assets.
+
+## Brand Color Helper
+
+Use the TypeScript helper when you prefer defining theme values from app code instead of the
+`ardo()` config. The default theme uses OKLCH hue tokens for brand, accent, and neutral chrome
+colors, so you can change the brand while keeping backgrounds, borders, header, sidebar, and text on
+a separate neutral base.
 
 Create a `.css.ts` file:
 

--- a/docs/app/routes/guide/site-ui.mdx
+++ b/docs/app/routes/guide/site-ui.mdx
@@ -80,6 +80,9 @@ mode visitors do not see a light-mode flash.
 Use `headerProps` when you want the default responsive header but need to configure the logo,
 navigation, search, theme toggle, or action area.
 
+If `brand.logo` is configured in `ardo()`, the default header uses it automatically. Pass
+`headerProps.logo` only when the header should use a different logo from the site brand.
+
 ```tsx
 import { ArdoNav, ArdoNavLink, ArdoSocialLink } from "ardo/ui"
 import logo from "./assets/logo.svg"

--- a/examples/basic/app/root.tsx
+++ b/examples/basic/app/root.tsx
@@ -3,7 +3,6 @@ import config from "virtual:ardo/config"
 import sidebar from "virtual:ardo/sidebar"
 import type { MetaFunction } from "react-router"
 import "ardo/ui/styles.css"
-import "./theme.css"
 
 export const meta: MetaFunction = () => [{ title: "Ardo Basic Example" }]
 

--- a/examples/basic/app/theme.css
+++ b/examples/basic/app/theme.css
@@ -1,5 +1,0 @@
-:root {
-  --ardo-brand-h: 250;
-  --ardo-brand-c: 0.14;
-  --ardo-brand-l: 0.48;
-}

--- a/examples/basic/vite.config.ts
+++ b/examples/basic/vite.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     ardo({
       title: "Ardo Basic Example",
       description: "A simple documentation site built with Ardo",
+      brand: {
+        color: "blue",
+        accent: "teal",
+        neutral: "slate",
+      },
       githubPages: false,
     }),
   ],

--- a/examples/library/app/root.tsx
+++ b/examples/library/app/root.tsx
@@ -3,7 +3,6 @@ import config from "virtual:ardo/config"
 import sidebar from "virtual:ardo/sidebar"
 import type { MetaFunction } from "react-router"
 import "ardo/ui/styles.css"
-import "./theme.css"
 
 export const meta: MetaFunction = () => [{ title: "Ardo Library Example" }]
 

--- a/examples/library/app/theme.css
+++ b/examples/library/app/theme.css
@@ -1,5 +1,0 @@
-:root {
-  --ardo-brand-h: 300;
-  --ardo-brand-c: 0.14;
-  --ardo-brand-l: 0.48;
-}

--- a/examples/library/vite.config.ts
+++ b/examples/library/vite.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     ardo({
       title: "Ardo Library Example",
       description: "A library documentation site with TypeDoc integration",
+      brand: {
+        color: "purple",
+        accent: "pink",
+        neutral: "slate",
+      },
       githubPages: false,
     }),
   ],

--- a/examples/monorepo/app/root.tsx
+++ b/examples/monorepo/app/root.tsx
@@ -3,7 +3,6 @@ import config from "virtual:ardo/config"
 import sidebar from "virtual:ardo/sidebar"
 import type { MetaFunction } from "react-router"
 import "ardo/ui/styles.css"
-import "./theme.css"
 
 export const meta: MetaFunction = () => [{ title: "Ardo Monorepo Example" }]
 

--- a/examples/monorepo/app/theme.css
+++ b/examples/monorepo/app/theme.css
@@ -1,5 +1,0 @@
-:root {
-  --ardo-brand-h: 50;
-  --ardo-brand-c: 0.14;
-  --ardo-brand-l: 0.48;
-}

--- a/examples/monorepo/vite.config.ts
+++ b/examples/monorepo/vite.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     ardo({
       title: "Ardo Monorepo Example",
       description: "A monorepo documentation site with multiple TypeDoc entry points",
+      brand: {
+        color: "amber",
+        accent: "blue",
+        neutral: "slate",
+      },
       githubPages: false,
     }),
   ],

--- a/packages/ardo/README.md
+++ b/packages/ardo/README.md
@@ -41,6 +41,12 @@ export default defineConfig({
     ardo({
       title: "My Documentation",
       description: "Docs for my React library",
+      brand: {
+        color: "blue",
+        accent: "teal",
+        neutral: "slate",
+        logo: "./app/assets/logo.svg",
+      },
     }),
   ],
 })
@@ -48,7 +54,11 @@ export default defineConfig({
 
 The `ardo()` plugin handles build-time behavior: route generation, MDX processing, TypeDoc generation, search data, and static build metadata. UI configuration stays in React through `ArdoRoot` and component props.
 
-Ardo also generates the modern lean favicon set (`favicon.ico`, `icon.svg`, and `apple-touch-icon.png`) from the default Ardo mark. Use `icons: { source: "./app/assets/logo.svg" }` to generate those files from your own SVG, or `icons: false` to manage them from `public/`.
+Use `brand` for the common theme setup: primary color, accent color, neutral chrome tone, and the
+default header logo. Ardo also generates the modern lean favicon set (`favicon.ico`, `icon.svg`, and
+`apple-touch-icon.png`) from that local SVG logo when available. Use
+`icons: { source: "./app/assets/favicon.svg" }` when favicon assets should come from a different SVG,
+or `icons: false` to manage them from `public/`.
 
 ## Root layout
 

--- a/packages/ardo/src/config/brand.test.ts
+++ b/packages/ardo/src/config/brand.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { createBrandThemeCss, resolveBrandThemeHues } from "./brand"
+
+describe("resolveBrandThemeHues", () => {
+  it("resolves preset brand, accent, and neutral hues", () => {
+    expect(
+      resolveBrandThemeHues({ color: "blue", accent: "teal", neutral: "slate" })
+    ).toStrictEqual({
+      color: 240,
+      accent: 170,
+      neutral: 260,
+    })
+  })
+
+  it("derives accent and neutral hues from color", () => {
+    expect(resolveBrandThemeHues({ color: 240 })).toStrictEqual({
+      color: 240,
+      accent: 114,
+      neutral: 240,
+    })
+  })
+
+  it("normalizes numeric hues", () => {
+    expect(resolveBrandThemeHues({ color: -10, accent: 370, neutral: 720 })).toStrictEqual({
+      color: 350,
+      accent: 10,
+      neutral: 0,
+    })
+  })
+})
+
+describe("createBrandThemeCss", () => {
+  it("emits hue variable overrides for configured brand values", () => {
+    expect(createBrandThemeCss({ color: "blue", accent: "teal", neutral: "slate" })).toBe(
+      ":root{--ardo-hue-brand:240;--ardo-hue-accent:170;--ardo-hue-neutral:260;}"
+    )
+  })
+
+  it("returns undefined when no brand hues are configured", () => {
+    expect(createBrandThemeCss({ logo: "./app/assets/logo.svg" })).toBeUndefined()
+  })
+})

--- a/packages/ardo/src/config/brand.test.ts
+++ b/packages/ardo/src/config/brand.test.ts
@@ -21,6 +21,14 @@ describe("resolveBrandThemeHues", () => {
     })
   })
 
+  it("keeps indigo distinct from neutral gray and slate presets", () => {
+    expect(resolveBrandThemeHues({ color: "indigo", neutral: "slate" })).toStrictEqual({
+      color: 270,
+      accent: 144,
+      neutral: 260,
+    })
+  })
+
   it("normalizes numeric hues", () => {
     expect(resolveBrandThemeHues({ color: -10, accent: 370, neutral: 720 })).toStrictEqual({
       color: 350,

--- a/packages/ardo/src/config/brand.ts
+++ b/packages/ardo/src/config/brand.ts
@@ -1,0 +1,98 @@
+import type { ArdoBrandConfig, ArdoBrandHue } from "./types"
+
+export const brandHuePresets = {
+  amber: 70,
+  berry: 356,
+  blue: 240,
+  gray: 260,
+  green: 130,
+  indigo: 260,
+  orange: 45,
+  pink: 330,
+  purple: 290,
+  red: 25,
+  slate: 260,
+  teal: 170,
+} as const
+
+type BrandHueKey = "accent" | "color" | "neutral"
+
+export type ResolvedBrandHues = Partial<Record<BrandHueKey, number>>
+
+const DEFAULT_SECONDARY_OFFSET = 234
+
+export function resolveBrandThemeHues(brand: ArdoBrandConfig | undefined): ResolvedBrandHues {
+  if (brand == null) {
+    return {}
+  }
+
+  const color = resolveBrandHue(brand.color, "color")
+  return {
+    color,
+    accent:
+      brand.accent === undefined
+        ? color === undefined
+          ? undefined
+          : defaultAccent(color)
+        : resolveBrandHue(brand.accent, "accent"),
+    neutral: brand.neutral === undefined ? color : resolveBrandHue(brand.neutral, "neutral"),
+  }
+}
+
+export function createBrandThemeCss(brand: ArdoBrandConfig | undefined): string | undefined {
+  const hues = resolveBrandThemeHues(brand)
+  const declarations = [
+    createHueDeclaration("brand", hues.color),
+    createHueDeclaration("accent", hues.accent),
+    createHueDeclaration("neutral", hues.neutral),
+  ].filter((declaration) => declaration !== undefined)
+
+  if (declarations.length === 0) {
+    return undefined
+  }
+
+  return `:root{${declarations.join("")}}`
+}
+
+export function resolveBrandHue(
+  value: ArdoBrandHue | undefined,
+  key: BrandHueKey
+): number | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError(`brand.${key} must be a finite hue number or a known preset.`)
+    }
+    return normalizeHue(value)
+  }
+
+  const presetName: unknown = value
+  if (!isBrandHuePresetName(presetName)) {
+    throw new TypeError(
+      `brand.${key} must be one of ${Object.keys(brandHuePresets)
+        .map((name) => `"${name}"`)
+        .join(", ")} or a hue number.`
+    )
+  }
+
+  return brandHuePresets[presetName]
+}
+
+function isBrandHuePresetName(value: unknown): value is keyof typeof brandHuePresets {
+  return typeof value === "string" && value in brandHuePresets
+}
+
+function defaultAccent(color: number): number {
+  return normalizeHue(color + DEFAULT_SECONDARY_OFFSET)
+}
+
+function normalizeHue(value: number): number {
+  return ((value % 360) + 360) % 360
+}
+
+function createHueDeclaration(name: "accent" | "brand" | "neutral", value: number | undefined) {
+  return value === undefined ? undefined : `--ardo-hue-${name}:${value};`
+}

--- a/packages/ardo/src/config/brand.ts
+++ b/packages/ardo/src/config/brand.ts
@@ -6,7 +6,7 @@ export const brandHuePresets = {
   blue: 240,
   gray: 260,
   green: 130,
-  indigo: 260,
+  indigo: 270,
   orange: 45,
   pink: 330,
   purple: 290,

--- a/packages/ardo/src/config/index.test.ts
+++ b/packages/ardo/src/config/index.test.ts
@@ -84,6 +84,28 @@ describe("resolveConfig", () => {
     })
   })
 
+  it("preserves brand configuration", () => {
+    const resolved = resolveConfig(
+      {
+        title: "Test",
+        brand: {
+          color: "blue",
+          accent: "teal",
+          neutral: "slate",
+          logo: "./app/assets/logo.svg",
+        },
+      },
+      "/project"
+    )
+
+    expect(resolved.brand).toStrictEqual({
+      color: "blue",
+      accent: "teal",
+      neutral: "slate",
+      logo: "./app/assets/logo.svg",
+    })
+  })
+
   it("merges markdown config with defaults", () => {
     const config = {
       title: "Test",
@@ -137,5 +159,18 @@ describe("resolveConfig", () => {
     expect(() =>
       resolveConfig({ title: "Test", seo: { sitemap: { priority: 2 } } }, "/project")
     ).toThrow("seo.sitemap.priority must be between 0 and 1")
+  })
+
+  it("rejects unknown brand hue presets", () => {
+    expect(() =>
+      resolveConfig(
+        {
+          title: "Test",
+          // @ts-expect-error exercising runtime validation for JavaScript configs.
+          brand: { color: "cerulean" },
+        },
+        "/project"
+      )
+    ).toThrow("brand.color must be one of")
   })
 })

--- a/packages/ardo/src/config/index.ts
+++ b/packages/ardo/src/config/index.ts
@@ -3,6 +3,10 @@ import path from "node:path"
 import { URL } from "node:url"
 
 import type {
+  ArdoBrandConfig,
+  ArdoBrandHue,
+  ArdoBrandHuePreset,
+  ArdoBrandLogo,
   ArdoConfig,
   HeadConfig,
   LinkCheckConfig,
@@ -27,11 +31,17 @@ import type {
   TypeDocConfig,
 } from "./types"
 
+import { resolveBrandThemeHues } from "./brand"
+
 type ConfigModule = {
   default?: unknown
 }
 
 export type {
+  ArdoBrandConfig,
+  ArdoBrandHue,
+  ArdoBrandHuePreset,
+  ArdoBrandLogo,
   ArdoConfig,
   HeadConfig,
   LinkCheckConfig,
@@ -97,6 +107,7 @@ export function resolveConfig(config: ArdoConfig, root: string): ResolvedConfig 
     },
     sidebar: config.sidebar ?? {},
     metadata: config.metadata ?? {},
+    brand: config.brand ?? {},
     vite: config.vite,
     project: config.project ?? {},
     root,
@@ -163,6 +174,8 @@ function validateConfig(config: ArdoConfig): void {
     errors.push("siteUrl must be an absolute URL.")
   }
 
+  validateBrandConfig(config, errors)
+
   const sitemapPriority =
     typeof config.seo?.sitemap === "object" ? config.seo.sitemap.priority : undefined
   if (
@@ -174,6 +187,14 @@ function validateConfig(config: ArdoConfig): void {
 
   if (errors.length > 0) {
     throw new Error(`[ardo] Invalid config:\n${errors.map((error) => `- ${error}`).join("\n")}`)
+  }
+}
+
+function validateBrandConfig(config: ArdoConfig, errors: string[]): void {
+  try {
+    resolveBrandThemeHues(config.brand)
+  } catch (error) {
+    errors.push(error instanceof Error ? error.message : String(error))
   }
 }
 

--- a/packages/ardo/src/config/types.ts
+++ b/packages/ardo/src/config/types.ts
@@ -68,6 +68,39 @@ export type SocialLink = {
 }
 
 // =============================================================================
+// Brand Config
+// =============================================================================
+
+export type ArdoBrandHuePreset =
+  | "amber"
+  | "berry"
+  | "blue"
+  | "gray"
+  | "green"
+  | "indigo"
+  | "orange"
+  | "pink"
+  | "purple"
+  | "red"
+  | "slate"
+  | "teal"
+
+export type ArdoBrandHue = ArdoBrandHuePreset | number
+
+export type ArdoBrandLogo = { light: string; dark: string } | string
+
+export type ArdoBrandConfig = {
+  /** Main brand hue used by primary accents and calls to action. */
+  color?: ArdoBrandHue
+  /** Accent hue used by secondary accents and code surfaces. Defaults from color. */
+  accent?: ArdoBrandHue
+  /** Neutral chrome hue used by backgrounds, borders, text, header, and sidebar. */
+  neutral?: ArdoBrandHue
+  /** Header logo path/URL, optionally with light/dark variants. */
+  logo?: ArdoBrandLogo
+}
+
+// =============================================================================
 // Markdown Config
 // =============================================================================
 
@@ -193,6 +226,8 @@ export type ArdoConfig = {
   sidebar?: SidebarConfig
   /** Site-level social metadata defaults */
   metadata?: MetadataConfig
+  /** Simple brand customization for the default theme and header logo. */
+  brand?: ArdoBrandConfig
   /** Sitemap and robots.txt generation */
   seo?: SeoConfig
   /** Build-time internal link checking */

--- a/packages/ardo/src/index.ts
+++ b/packages/ardo/src/index.ts
@@ -1,6 +1,10 @@
 // Config (client-safe: pure types and small utility functions)
 export { defineConfig, loadConfig, resolveConfig } from "./config"
 export type {
+  ArdoBrandConfig,
+  ArdoBrandHue,
+  ArdoBrandHuePreset,
+  ArdoBrandLogo,
   ArdoConfig,
   HeadConfig,
   LlmsConfig,

--- a/packages/ardo/src/ui/ArdoRoot.tsx
+++ b/packages/ardo/src/ui/ArdoRoot.tsx
@@ -3,6 +3,7 @@ import { Outlet, useLocation, useMatches } from "react-router"
 
 import type { ArdoConfig, ArdoContextItem, SidebarItem } from "../config/types"
 
+import { createBrandThemeCss } from "../config/brand"
 import { ArdoProvider, type ArdoSiteConfig, ArdoSiteConfigProvider } from "../runtime/hooks"
 import { ArdoFooter, type ArdoFooterProps } from "./Footer"
 import { ArdoHeader, type ArdoHeaderProps } from "./Header"
@@ -187,6 +188,12 @@ function resolveContextSidebar(
   return sidebar[activeContext.id] ?? []
 }
 
+function ArdoBrandThemeStyle({ brand }: { brand: ArdoConfig["brand"] }) {
+  const css = createBrandThemeCss(brand)
+  if (css === undefined) return null
+  return <style data-ardo-brand dangerouslySetInnerHTML={{ __html: css }} />
+}
+
 export function ArdoRoot({
   config,
   sidebar,
@@ -220,10 +227,14 @@ export function ArdoRoot({
     () => resolveContextSidebar(sidebar, activeContext),
     [sidebar, activeContext]
   )
+  const resolvedHeaderProps =
+    config.brand?.logo === undefined || headerProps?.logo !== undefined
+      ? headerProps
+      : { ...headerProps, logo: config.brand.logo }
   // Search lives in the header now. The sidebar no longer carries it.
   const resolvedSidebar = isBareLayout ? undefined : resolveSidebar(sidebarContent, sidebarProps)
   const resolvedHeader = showChrome
-    ? resolveRootHeader(header, headerProps, isBareLayout ? undefined : resolvedSidebar)
+    ? resolveRootHeader(header, resolvedHeaderProps, isBareLayout ? undefined : resolvedSidebar)
     : null
   const resolvedFooter = showChrome ? (
     footer === undefined ? (
@@ -239,21 +250,24 @@ export function ArdoRoot({
   )
 
   const content = (
-    <ArdoProvider
-      config={config}
-      sidebar={sidebarItems}
-      contexts={contexts}
-      activeContextId={activeContext?.id}
-    >
-      <ArdoLayout
-        className={resolveLayoutClassName(className, isBareLayout)}
-        header={resolvedHeader}
-        sidebar={resolvedSidebar}
-        footer={resolvedFooter}
+    <>
+      <ArdoBrandThemeStyle brand={config.brand} />
+      <ArdoProvider
+        config={config}
+        sidebar={sidebarItems}
+        contexts={contexts}
+        activeContextId={activeContext?.id}
       >
-        {children ?? <Outlet />}
-      </ArdoLayout>
-    </ArdoProvider>
+        <ArdoLayout
+          className={resolveLayoutClassName(className, isBareLayout)}
+          header={resolvedHeader}
+          sidebar={resolvedSidebar}
+          footer={resolvedFooter}
+        >
+          {children ?? <Outlet />}
+        </ArdoLayout>
+      </ArdoProvider>
+    </>
   )
 
   const hasSiteConfig =

--- a/packages/ardo/src/ui/shell.test.tsx
+++ b/packages/ardo/src/ui/shell.test.tsx
@@ -95,4 +95,29 @@ describe("UI shell landmarks", () => {
     expect(view).not.toContain("ardo-header")
     expect(view).not.toContain("ardo-footer")
   })
+
+  it("applies brand hue styles and logo defaults", () => {
+    const view = renderRootRoute(
+      <ArdoRoot
+        config={{
+          title: "Docs",
+          brand: {
+            color: "blue",
+            accent: "teal",
+            neutral: "slate",
+            logo: "/logo.svg",
+          },
+        }}
+        sidebar={[]}
+      >
+        <p>Content</p>
+      </ArdoRoot>
+    )
+
+    expect(view).toContain("data-ardo-brand")
+    expect(view).toContain("--ardo-hue-brand:240")
+    expect(view).toContain("--ardo-hue-accent:170")
+    expect(view).toContain("--ardo-hue-neutral:260")
+    expect(view).toContain('<img src="/logo.svg" alt="Docs"')
+  })
 })

--- a/packages/ardo/src/vite/brand.ts
+++ b/packages/ardo/src/vite/brand.ts
@@ -1,0 +1,92 @@
+import path from "node:path"
+
+import type { ArdoBrandLogo, ResolvedConfig } from "../config/types"
+import type { ArdoIconOptions } from "./icons"
+
+import { normalizePath } from "./path-utils"
+
+type VirtualClientConfig = {
+  buildHash: string | undefined
+  buildTime: string
+} & Pick<ResolvedConfig, "base" | "brand" | "description" | "lang" | "project" | "title">
+
+export function resolveBrandIconOptions(
+  icons: ArdoIconOptions | undefined,
+  logo: ArdoBrandLogo | undefined
+): ArdoIconOptions | undefined {
+  if (icons === false || icons?.source !== undefined) {
+    return icons
+  }
+
+  const source = getLocalLogoSource(logo)
+  if (source === undefined) {
+    return icons
+  }
+
+  return { ...icons, source }
+}
+
+export function serializeVirtualConfigModule(
+  clientConfig: VirtualClientConfig,
+  root: string
+): string {
+  const imports: string[] = []
+  const logoExpression = serializeBrandLogo(clientConfig.brand.logo, root, imports)
+  const { logo: _logo, ...brandWithoutLogo } = clientConfig.brand
+  const configWithoutLogo = { ...clientConfig, brand: brandWithoutLogo }
+  const lines = [...imports, `const config = ${JSON.stringify(configWithoutLogo)}`]
+
+  if (logoExpression !== undefined) {
+    lines.push(`config.brand = { ...(config.brand ?? {}), logo: ${logoExpression} }`)
+  }
+
+  lines.push("export default config")
+  return lines.join("\n")
+}
+
+function getLocalLogoSource(logo: ArdoBrandLogo | undefined): string | undefined {
+  const source = typeof logo === "string" ? logo : logo?.light
+  return source !== undefined && isLocalAssetReference(source) ? source : undefined
+}
+
+function serializeBrandLogo(
+  logo: ArdoBrandLogo | undefined,
+  root: string,
+  imports: string[]
+): string | undefined {
+  if (logo === undefined) {
+    return undefined
+  }
+
+  if (typeof logo === "string") {
+    return serializeAssetReference(logo, root, imports)
+  }
+
+  const light = serializeAssetReference(logo.light, root, imports)
+  const dark = serializeAssetReference(logo.dark, root, imports)
+  return `{ light: ${light}, dark: ${dark} }`
+}
+
+function serializeAssetReference(source: string, root: string, imports: string[]): string {
+  if (!isLocalAssetReference(source)) {
+    return JSON.stringify(source)
+  }
+
+  const identifier = `__ardoBrandLogo${imports.length}`
+  imports.push(`import ${identifier} from ${JSON.stringify(toAssetImportPath(root, source))}`)
+  return identifier
+}
+
+function isLocalAssetReference(source: string): boolean {
+  return (
+    !source.startsWith("/") &&
+    !source.startsWith("http://") &&
+    !source.startsWith("https://") &&
+    !source.startsWith("data:") &&
+    !source.startsWith("blob:")
+  )
+}
+
+function toAssetImportPath(root: string, source: string): string {
+  return normalizePath(path.resolve(root, source))
+}

--- a/packages/ardo/src/vite/llms-text.test.ts
+++ b/packages/ardo/src/vite/llms-text.test.ts
@@ -7,6 +7,7 @@ import { createLlmsTextAssets, generateLlmsFullTxt, generateLlmsTxt } from "./ll
 
 const config: ResolvedConfig = {
   base: "/docs/",
+  brand: {},
   contentDir: "/tmp/routes",
   description: "Framework docs",
   head: [],

--- a/packages/ardo/src/vite/plugin.test.ts
+++ b/packages/ardo/src/vite/plugin.test.ts
@@ -95,4 +95,50 @@ describe("ardoPlugin", () => {
 
     expect(String(code)).toContain('"base":"/"')
   })
+
+  it("exposes brand config with bundled local logo assets", async () => {
+    const plugin = getMainPlugin({
+      githubPages: false,
+      title: "Docs",
+      brand: {
+        color: "blue",
+        accent: "teal",
+        neutral: "slate",
+        logo: "./app/assets/logo.svg",
+      },
+    })
+
+    plugin.configResolved({
+      base: "/",
+      build: { ssr: false },
+      root: "/project",
+    })
+
+    const code = await plugin.load("\0virtual:ardo/config")
+
+    expect(String(code)).toContain('import __ardoBrandLogo0 from "/project/app/assets/logo.svg"')
+    expect(String(code)).toContain('"brand":{"color":"blue","accent":"teal","neutral":"slate"}')
+    expect(String(code)).toContain("logo: __ardoBrandLogo0")
+  })
+
+  it("keeps public brand logo URLs as direct config values", async () => {
+    const plugin = getMainPlugin({
+      githubPages: false,
+      title: "Docs",
+      brand: {
+        logo: "/logo.svg",
+      },
+    })
+
+    plugin.configResolved({
+      base: "/",
+      build: { ssr: false },
+      root: "/project",
+    })
+
+    const code = await plugin.load("\0virtual:ardo/config")
+
+    expect(String(code)).not.toContain("import __ardoBrandLogo")
+    expect(String(code)).toContain('logo: "/logo.svg"')
+  })
 })

--- a/packages/ardo/src/vite/plugin.ts
+++ b/packages/ardo/src/vite/plugin.ts
@@ -5,6 +5,7 @@ import type { ArdoConfig, ProjectMeta, ResolvedConfig } from "../config/types"
 
 import { resolveConfig } from "../config/index"
 import { normalizeViteBaseForArdo } from "./base"
+import { resolveBrandIconOptions, serializeVirtualConfigModule } from "./brand"
 import {
   checkInternalLinks,
   createBuildOutputAssets,
@@ -94,7 +95,7 @@ export function ardoPlugin(options: ArdoPluginOptions = {}): Plugin[] {
 
   const mainPluginOptions: MainPluginOptions = { githubPages, pressConfig, routesDirOption }
   const plugins: Plugin[] = [createMainPlugin(state, mainPluginOptions)]
-  plugins.push(...createIconsPlugin(icons))
+  plugins.push(...createIconsPlugin(resolveBrandIconOptions(icons, pressConfig.brand?.logo)))
   addRoutesPlugin(plugins, routes, routesDirOption)
   addTypeDocPlugin(plugins, typedoc, routesDirOption)
 
@@ -284,11 +285,12 @@ async function loadVirtualModule(id: string, state: PluginState): Promise<string
       description: state.resolvedConfig.description,
       base: state.resolvedConfig.base,
       lang: state.resolvedConfig.lang,
+      brand: state.resolvedConfig.brand,
       project: state.resolvedConfig.project,
       buildTime: new Date().toISOString(),
       buildHash: detectGitHash(state.resolvedConfig.root),
     }
-    return `export default ${JSON.stringify(clientConfig)}`
+    return serializeVirtualConfigModule(clientConfig, state.resolvedConfig.root)
   }
 
   if (id === RESOLVED_IDS[VIRTUAL_SIDEBAR_ID]) {


### PR DESCRIPTION
## Summary

Adds a simple `brand` shortcut to `ardo()` for the default documentation theme:

- supports `brand.color`, `brand.accent`, and `brand.neutral` as hue numbers or named presets
- uses `brand.logo` as the default header logo and local SVG favicon source
- serializes local logo paths through `virtual:ardo/config` so Vite still bundles the asset
- updates docs, README, and examples to show the new brand-first setup

## Validation

- `CI=true pnpm typecheck`
- `CI=true pnpm test:unit`
- `CI=true pnpm lint`