### PR TITLE
feat!: harden v4 docs deployment readiness

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -55,10 +55,13 @@ jobs:
           mkdir -p docs/build/client/storybook
           cp -r storybook-static/* docs/build/client/storybook/
 
+      - name: Prepare GitHub Pages artifact
+        run: node scripts/prepare-pages-artifact.mjs
+
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: docs/build/client
+          path: docs/build/pages
 
   deploy:
     name: Deploy docs

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
 [![Node](https://img.shields.io/badge/Node-%3E%3D22.0.0-green.svg)](https://nodejs.org/)
 
-[Documentation](https://ardo-docs.dev) ·
-[Getting Started](https://ardo-docs.dev/guide/getting-started) ·
-[API Reference](https://ardo-docs.dev/api-reference) ·
+[Documentation](https://ardo-docs.dev/v3/) ·
+[Getting Started](https://ardo-docs.dev/v3/guide/getting-started) ·
+[API Reference](https://ardo-docs.dev/v3/api-reference) ·
 [Examples](https://github.com/sebastian-software/ardo/tree/main/examples)
 
 </div>
@@ -30,12 +30,12 @@ React or moving docs into a closed platform.
 The full product overview, comparison, configuration reference, deployment notes, and roadmap live
 on the documentation site:
 
-- [What is Ardo?](https://ardo-docs.dev/guide/what-is-ardo)
-- [Getting Started](https://ardo-docs.dev/guide/getting-started)
-- [Comparison](https://ardo-docs.dev/guide/comparison)
-- [Configuration](https://ardo-docs.dev/guide/configuration)
-- [Deployment](https://ardo-docs.dev/guide/deployment)
-- [Feature Status](https://ardo-docs.dev/guide/status-roadmap)
+- [What is Ardo?](https://ardo-docs.dev/v3/guide/what-is-ardo)
+- [Getting Started](https://ardo-docs.dev/v3/guide/getting-started)
+- [Comparison](https://ardo-docs.dev/v3/guide/comparison)
+- [Configuration](https://ardo-docs.dev/v3/guide/configuration)
+- [Deployment](https://ardo-docs.dev/v3/guide/deployment)
+- [Feature Status](https://ardo-docs.dev/v3/guide/status-roadmap)
 
 ## Quick start
 
@@ -50,7 +50,7 @@ Open `http://localhost:5173`. Add an `.mdx` file to `app/routes/`, and Ardo adds
 generated sidebar.
 
 For manual installation, existing workspaces, TypeDoc setup, theming, and deployment, use the
-[Getting Started guide](https://ardo-docs.dev/guide/getting-started).
+[Getting Started guide](https://ardo-docs.dev/v3/guide/getting-started).
 
 ## Examples
 

--- a/docs/app/routes/guide/deployment.mdx
+++ b/docs/app/routes/guide/deployment.mdx
@@ -112,6 +112,11 @@ content. On GitHub Pages, the root redirect is a static `index.html` file. If yo
 behind a CDN or host that supports HTTP redirects, configure that provider-level redirect outside
 Ardo.
 
+When `versions.json` lists older major versions, do not upload only the fresh `build/client` folder
+to GitHub Pages. GitHub Pages replaces the full artifact on every deploy, so use a staging directory
+that combines the current build with retained static folders for older majors before calling
+`actions/upload-pages-artifact`.
+
 ### Step 2: Add a GitHub Actions Workflow
 
 Create `.github/workflows/deploy.yml` in your repository:

--- a/docs/app/routes/guide/upgrade-to-v4.mdx
+++ b/docs/app/routes/guide/upgrade-to-v4.mdx
@@ -1,0 +1,87 @@
+---
+title: Upgrade to Ardo 4.0
+description: Prepare an Ardo project for the 4.0 release and the stable major-version URL contract.
+order: 13
+---
+
+# Upgrade to Ardo 4.0
+
+Ardo 4.0 uses the breaking-release window to stabilize documentation URL identity. The main public
+change is the major-version URL contract: production documentation should live under a stable major
+folder such as `/v3/` or `/v4/`, while `/` redirects to the current major version.
+
+## What Changes
+
+- Major-versioned documentation URLs become the recommended public shape for deployed docs.
+- Root `index.html`, `versions.json`, `sitemap.xml`, `robots.txt`, `llms.txt`, search assets, and
+  redirect files are emitted as static build outputs.
+- `sitemap.xml` advertises only the current canonical major version so older folders can stay
+  reachable without being indexed as duplicate current content.
+- GitHub Pages deployments should preserve older major folders when a new major version becomes
+  current.
+
+## Update Versioned Docs
+
+Configure the current major version in `vite.config.ts`:
+
+```ts
+import { defineConfig } from "vite"
+import { ardo } from "ardo/vite"
+
+export default defineConfig({
+  plugins: [
+    ardo({
+      title: "My Docs",
+      siteUrl: "https://docs.example.com",
+      versioning: {
+        current: "v4",
+        versions: [
+          { id: "v4", label: "4.x", path: "/v4/" },
+          { id: "v3", label: "3.x", path: "/v3/" },
+        ],
+      },
+    }),
+  ],
+})
+```
+
+Set the same basename in `react-router.config.ts`:
+
+```ts
+import type { Config } from "@react-router/dev/config"
+import { withArdoVersioning } from "ardo/vite"
+
+const config = {
+  ssr: false,
+  prerender: true,
+} satisfies Config
+
+export default withArdoVersioning(config, { basename: "/v4/" })
+```
+
+## Preserve Older GitHub Pages Versions
+
+GitHub Pages replaces the full uploaded artifact on each deploy. Before switching the current docs
+build to a new major folder, keep the final generated folder for the previous major version and copy
+it into the Pages artifact during deployment.
+
+For this repository, older major snapshots live under `docs/version-snapshots/`:
+
+```text
+docs/version-snapshots/v3/
+```
+
+The Pages workflow fails if `versions.json` lists an older major version that is missing from both
+the current build and `docs/version-snapshots/`. This protects stable URLs such as `/v3/...` from
+being deleted by the first `/v4/` deployment.
+
+## Check Existing Links
+
+Update external documentation links to point at the versioned canonical URL:
+
+```text
+https://docs.example.com/v4/guide/getting-started
+```
+
+Avoid making `latest` canonical. If a `latest` alias is added later, it should redirect to the
+current major-version folder.

--- a/docs/version-snapshots/README.md
+++ b/docs/version-snapshots/README.md
@@ -1,0 +1,16 @@
+# Version Snapshots
+
+GitHub Pages deploys replace the full published artifact. Keep older major-version folders here
+when a new major docs version becomes current, so stable inbound links keep resolving after the next
+deploy.
+
+For example, before switching the docs build from `/v3/` to `/v4/`, add the final generated `v3`
+folder at:
+
+```text
+docs/version-snapshots/v3/
+```
+
+The Pages workflow copies `docs/build/client` into a staging artifact, then fills any version folder
+listed in `versions.json` that the current build did not produce from this directory. If a listed
+older major version is missing from both places, the workflow fails before uploading to GitHub Pages.

--- a/packages/ardo/src/config/index.ts
+++ b/packages/ardo/src/config/index.ts
@@ -35,7 +35,7 @@ import type {
 
 import { resolveBrandThemeHues } from "./brand"
 import { resolveI18nConfig } from "./i18n"
-import { resolveVersionedBase, resolveVersioningConfig } from "./versioning"
+import { normalizeBasePath, resolveVersionedBase, resolveVersioningConfig } from "./versioning"
 
 type ConfigModule = {
   default?: unknown
@@ -102,6 +102,7 @@ export function resolveConfig(config: ArdoConfig, root: string): ResolvedConfig 
     description: config.description ?? "",
     titleSeparator: config.titleSeparator ?? " | ",
     base: resolveVersionedBase(deploymentBase, versioning),
+    deploymentBase: normalizeBasePath(deploymentBase),
     siteUrl: config.siteUrl ?? "",
     srcDir,
     outDir: config.outDir ?? "dist",

--- a/packages/ardo/src/config/types.ts
+++ b/packages/ardo/src/config/types.ts
@@ -411,6 +411,14 @@ export type PageData = {
 // =============================================================================
 
 export type ResolvedConfig = {
+  /**
+   * The configured deployment base before version and locale prefixes are applied.
+   *
+   * `base` is the canonical public route base used by the app runtime. Root-emitted
+   * files such as `robots.txt`, `sitemap.xml`, and `llms.txt` need this unversioned
+   * base because they are written beside the version folders.
+   */
+  deploymentBase: string
   project: ProjectMeta
   vite?: Record<string, unknown>
   typedoc?: TypeDocConfig

--- a/packages/ardo/src/vite/build-outputs.test.ts
+++ b/packages/ardo/src/vite/build-outputs.test.ts
@@ -117,6 +117,33 @@ describe("build outputs", () => {
     expect(sitemap).not.toContain("/docs/v2/")
   })
 
+  it("keeps root asset cross-references on the deployment base for versioned docs", () => {
+    const versionedConfig = resolveConfig(
+      {
+        title: "Docs",
+        base: "/docs/",
+        siteUrl: "https://example.com",
+        versioning: {
+          current: "v3",
+          versions: [{ id: "v3", label: "3.x", path: "/v3/" }],
+        },
+      },
+      "/site"
+    )
+    const assets = createBuildOutputAssets(createEntries(versionedConfig), versionedConfig)
+    const robots = generateRobots(versionedConfig)
+    const llms = assets.find((asset) => asset.fileName === "llms.txt")
+
+    expect(generateSitemap(createEntries(versionedConfig), versionedConfig)).toContain(
+      "<loc>https://example.com/docs/v3/guide</loc>"
+    )
+    expect(robots).toContain("Sitemap: https://example.com/docs/sitemap.xml")
+    expect(robots).not.toContain("https://example.com/docs/v3/sitemap.xml")
+    expect(llms?.source).toContain("- [Full documentation](https://example.com/docs/llms-full.txt)")
+    expect(llms?.source).not.toContain("https://example.com/docs/v3/llms-full.txt")
+    expect(llms?.source).toContain("- [Guide](https://example.com/docs/v3/guide)")
+  })
+
   it("combines configured and frontmatter redirects for provider outputs", () => {
     const redirects = collectRedirects(entries, {
       ...baseConfig,

--- a/packages/ardo/src/vite/build-outputs.ts
+++ b/packages/ardo/src/vite/build-outputs.ts
@@ -326,7 +326,7 @@ function dedupeRedirects(redirects: Array<{ from: string; to: string }>) {
 }
 
 function toAbsoluteUrl(routePath: string, config: ResolvedConfig) {
-  const basePath = joinUrlPath(config.base, routePath)
+  const basePath = joinUrlPath(config.deploymentBase, routePath)
   if (config.siteUrl === "") {
     return basePath
   }

--- a/packages/ardo/src/vite/llms-text.test.ts
+++ b/packages/ardo/src/vite/llms-text.test.ts
@@ -11,6 +11,7 @@ const config: ResolvedConfig = {
   base: "/docs/",
   brand: {},
   contentDir: "/tmp/routes",
+  deploymentBase: "/docs/",
   description: "Framework docs",
   head: [],
   i18n: false,

--- a/packages/ardo/src/vite/llms-text.ts
+++ b/packages/ardo/src/vite/llms-text.ts
@@ -214,7 +214,7 @@ function findLastRouteSegment(routePath: string): string {
 }
 
 function toAbsoluteUrl(routePath: string, config: ResolvedConfig) {
-  const basePath = buildPublicPath({ basePath: config.base, routePath })
+  const basePath = buildPublicPath({ basePath: config.deploymentBase, routePath })
   if (config.siteUrl === "") {
     return basePath
   }

--- a/scripts/prepare-pages-artifact.mjs
+++ b/scripts/prepare-pages-artifact.mjs
@@ -49,7 +49,7 @@ async function readVersions(filePath) {
   try {
     const raw = await fs.readFile(filePath, "utf8")
     const parsed = JSON.parse(raw)
-    if (!Array.isArray(parsed.versions)) {
+    if (typeof parsed !== "object" || parsed === null || !Array.isArray(parsed.versions)) {
       return []
     }
 

--- a/scripts/prepare-pages-artifact.mjs
+++ b/scripts/prepare-pages-artifact.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises"
+import path from "node:path"
+
+const root = process.cwd()
+const clientDir = path.resolve(root, process.env.ARDO_PAGES_CLIENT_DIR ?? "docs/build/client")
+const artifactDir = path.resolve(root, process.env.ARDO_PAGES_ARTIFACT_DIR ?? "docs/build/pages")
+const snapshotsDir = path.resolve(
+  root,
+  process.env.ARDO_PAGES_VERSION_SNAPSHOTS_DIR ?? "docs/version-snapshots"
+)
+
+await resetDirectory(artifactDir)
+await copyDirectory(clientDir, artifactDir)
+
+const versions = await readVersions(path.join(clientDir, "versions.json"))
+for (const version of versions) {
+  const versionFolder = normalizeVersionFolder(version.path)
+  if (versionFolder == null) {
+    continue
+  }
+
+  const generatedVersionDir = path.join(artifactDir, versionFolder)
+  if (await pathExists(generatedVersionDir)) {
+    continue
+  }
+
+  const snapshotDir = path.join(snapshotsDir, versionFolder)
+  if (await pathExists(snapshotDir)) {
+    await copyDirectory(snapshotDir, generatedVersionDir)
+    console.log(`Preserved ${version.id} from ${path.relative(root, snapshotDir)}`)
+    continue
+  }
+
+  throw new Error(
+    [
+      `Missing deployed docs for ${version.id} (${version.path}).`,
+      `The current build did not produce ${path.relative(root, generatedVersionDir)},`,
+      `and no snapshot exists at ${path.relative(root, snapshotDir)}.`,
+      "Add a snapshot before cutting this release so GitHub Pages does not delete stable major-version URLs.",
+    ].join(" ")
+  )
+}
+
+console.log(`Prepared GitHub Pages artifact at ${path.relative(root, artifactDir)}`)
+
+async function readVersions(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, "utf8")
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed.versions)) {
+      return []
+    }
+
+    return parsed.versions.filter(
+      (version) =>
+        version != null && typeof version.id === "string" && typeof version.path === "string"
+    )
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return []
+    }
+
+    throw error
+  }
+}
+
+function normalizeVersionFolder(versionPath) {
+  const trimmed = versionPath.replaceAll(/^\/|\/$/gu, "")
+  return trimmed === "" ? null : trimmed
+}
+
+async function resetDirectory(directory) {
+  await fs.rm(directory, { force: true, recursive: true })
+  await fs.mkdir(directory, { recursive: true })
+}
+
+async function copyDirectory(source, destination) {
+  await fs.cp(source, destination, { recursive: true })
+}
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary
- force release-please onto 4.0.0 via a breaking commit and Release-As footer
- keep root-emitted robots/llms cross-references on the deployment base while page URLs stay versioned
- stage GitHub Pages artifacts so older major-version folders must be preserved from docs/version-snapshots before upload
- add the v4 upgrade guide and version README deep links

Refs #288

## Verification
- pnpm exec vitest run packages/ardo/src/vite/build-outputs.test.ts packages/ardo/src/vite/llms-text.test.ts
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm build
- pnpm docs:build (rerun outside the sandbox because React Router prerender opens a local preview server)
- node scripts/prepare-pages-artifact.mjs
- checked docs/build/client/robots.txt, docs/build/client/llms.txt, docs/build/client/sitemap.xml, and docs/build/client/versions.json output