### PR TITLE
fix: harden v4.2 release consumers and OpenAPI builds

### DIFF
--- a/docs/app/routes/guide/adopt-ardo.mdx
+++ b/docs/app/routes/guide/adopt-ardo.mdx
@@ -12,7 +12,7 @@ Ardo fits into an existing React, Vite, and React Router repository. Do not rege
 Set up Ardo in this repository. Read https://ardo-docs.dev/llms.txt first, then follow the "Adopt Ardo in an Existing Project" guide. Inspect the project, choose the closest Ardo reference project, propose a plan, and wait for approval before changing files. Preserve existing routing, components, styles, and deployment choices unless the plan explains a necessary change.
 ```
 
-`/llms.txt` is a concise map of the documentation; `/llms-full.txt` contains the complete Markdown context when an agent needs more detail. Both are generated with the docs build and match the released framework version.
+`/llms.txt` is a concise map of the documentation; `/llms-full.txt` contains the complete Markdown context when an agent needs more detail. Both are generated with the docs build for the documentation version being served.
 
 ## Choose a Reference Project
 

--- a/docs/app/routes/guide/component-inventory.mdx
+++ b/docs/app/routes/guide/component-inventory.mdx
@@ -66,7 +66,7 @@ These need a broader architectural decision or belong to their own product track
 - **API endpoint blocks** — belong to the OpenAPI track ([#69](https://github.com/sebastian-software/ardo/issues/69)) rather than standalone components.
 - **Twoslash / TypeScript hover examples** — high maintenance and toolchain weight relative to their reach.
 - **Sandpack or embedded live playgrounds** — the bundle and maintenance cost conflicts with Ardo's static-first, budget-guarded output.
-- **Schema-backed content collections, extension API, i18n, analytics/feedback adapters** — separate roadmap tracks (see [Feature Status](/guide/status-roadmap)).
+- **Public extension API, i18n, analytics/feedback adapters** — separate roadmap tracks (see [Feature Status](/guide/status-roadmap)).
 
 ## Guarantees for shipped components
 

--- a/docs/app/routes/guide/getting-started.mdx
+++ b/docs/app/routes/guide/getting-started.mdx
@@ -47,7 +47,7 @@ pnpm init
 ### 2. Install dependencies
 
 ```bash
-pnpm add ardo react react-dom react-router isbot
+pnpm add ardo lucide-react react react-dom react-router isbot
 pnpm add -D @react-router/dev @tailwindcss/vite tailwindcss typescript vite @types/react @types/react-dom
 ```
 
@@ -288,7 +288,9 @@ my-docs/
 The repository also includes runnable examples for common layouts:
 [basic](https://github.com/sebastian-software/ardo/tree/main/examples/basic),
 [library](https://github.com/sebastian-software/ardo/tree/main/examples/library), and
-[monorepo](https://github.com/sebastian-software/ardo/tree/main/examples/monorepo).
+[monorepo](https://github.com/sebastian-software/ardo/tree/main/examples/monorepo). For Markdown
+owned outside `app/routes/`, start with the
+[content sources reference](https://github.com/sebastian-software/ardo/tree/main/examples/content-sources).
 
 ## Next Steps
 

--- a/docs/app/routes/guide/reference-projects.mdx
+++ b/docs/app/routes/guide/reference-projects.mdx
@@ -6,7 +6,7 @@ order: 2.6
 
 # Reference Projects
 
-Ardo keeps three small reference projects in the repository. They are maintained as product contracts: each is integration-tested, readable in isolation, and a better starting point for a human or coding agent than a generic generator template.
+Ardo keeps four small reference projects in the repository. They are maintained as product contracts: each is integration-tested, readable in isolation, and a better starting point for a human or coding agent than a generic generator template.
 
 ## Product Documentation
 

--- a/docs/app/routes/guide/status-roadmap.mdx
+++ b/docs/app/routes/guide/status-roadmap.mdx
@@ -20,6 +20,7 @@ These capabilities are available in the current package line.
 | Syntax highlighting     | Shipped | Build-time Shiki highlighting for Markdown code fences and static `CodeBlock` usage.                                   |
 | Search                  | Shipped | Generated search data with a built-in search UI.                                                                       |
 | TypeDoc API reference   | Shipped | Built into the `ardo()` plugin for TypeScript library APIs.                                                            |
+| Content collections     | Shipped | Schema-validated local Markdown and MDX materialized as routes and typed static records for custom React views.        |
 | Social metadata         | Shipped | Generated canonical, Open Graph, and Twitter metadata for Markdown routes.                                             |
 | SEO build outputs       | Shipped | Sitemap, robots output, LLM text artifacts, link checking, and static redirects are supported.                         |
 | Theme hue overrides     | Shipped | Brand, accent, and neutral hue custom properties can retint the default color ramp from CSS.                           |

--- a/docs/app/routes/home.tsx
+++ b/docs/app/routes/home.tsx
@@ -182,7 +182,7 @@ export default function HomePage() {
               language="mdx"
               title="getting-started.mdx"
               code={
-                '---\ntitle: Getting Started\n---\n\n# Getting Started\n\nInstall Ardo with your favorite package manager:\n\n```bash\npnpm add ardo react react-dom\n```\n\n<Tip>\n  Start from the reference project closest to your repository.\n</Tip>\n\n<CustomAlert type="info">\n  You can use **any React component** in your docs.\n</CustomAlert>'
+                '---\ntitle: Getting Started\n---\n\n# Getting Started\n\nInstall Ardo with your favorite package manager:\n\n```bash\npnpm add ardo lucide-react react react-dom\n```\n\n<Tip>\n  Start from the reference project closest to your repository.\n</Tip>\n\n<CustomAlert type="info">\n  You can use **any React component** in your docs.\n</CustomAlert>'
               }
             />
           </div>

--- a/packages/ardo/package.json
+++ b/packages/ardo/package.json
@@ -105,9 +105,6 @@
     "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
-    "lucide-react": {
-      "optional": true
-    },
     "mermaid": {
       "optional": true
     }

--- a/packages/ardo/src/vite/openapi-plugin.test.ts
+++ b/packages/ardo/src/vite/openapi-plugin.test.ts
@@ -1,0 +1,33 @@
+import { resolveConfig } from "vite"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createOpenApiPlugin } from "./openapi-plugin"
+
+const { generateOpenApiDocs, writeRoutesFileSync } = vi.hoisted(() => ({
+  generateOpenApiDocs: vi.fn().mockResolvedValue(2),
+  writeRoutesFileSync: vi.fn(),
+}))
+
+vi.mock("./openapi", () => ({ generateOpenApiDocs }))
+vi.mock("./routes-core", () => ({ writeRoutesFileSync }))
+
+describe("createOpenApiPlugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("generates reference files only during the client build pass", async () => {
+    const ssrPlugin = createOpenApiPlugin({ spec: "openapi.yaml" }, undefined)
+    await resolveConfig({ build: { ssr: true }, plugins: [ssrPlugin], root: "/project" }, "build")
+
+    expect(generateOpenApiDocs).not.toHaveBeenCalled()
+    expect(writeRoutesFileSync).not.toHaveBeenCalled()
+
+    const plugin = createOpenApiPlugin({ spec: "openapi.yaml" }, undefined)
+    expect(plugin.buildEnd).toBeUndefined()
+    await resolveConfig({ plugins: [plugin], root: "/project" }, "build")
+
+    expect(generateOpenApiDocs).toHaveBeenCalledTimes(1)
+    expect(writeRoutesFileSync).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/ardo/src/vite/openapi-plugin.ts
+++ b/packages/ardo/src/vite/openapi-plugin.ts
@@ -16,9 +16,9 @@ export function createOpenApiPlugin(
   let generated = false
   return {
     name: "ardo:openapi",
-    async config(userConfig) {
+    async config(userConfig, env) {
       root = userConfig.root ?? root
-      if (generated) return
+      if (env.isSsrBuild || generated) return
       generated = true
       const routesDir = resolveRoutesDir(root, routesDirOption)
       await generateOpenApiDocs({ config, root, routesDir })
@@ -27,9 +27,6 @@ export function createOpenApiPlugin(
         routesDir,
         routesFilePath: path.join(root, "app", "routes.ts"),
       })
-    },
-    buildEnd() {
-      generated = false
     },
   }
 }

--- a/packages/create-ardo/src/scaffold.integration.test.ts
+++ b/packages/create-ardo/src/scaffold.integration.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process"
+import { execFileSync, execSync } from "node:child_process"
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
@@ -20,6 +20,20 @@ function collectFiles(dir: string, ext: string): string[] {
   }
   walk(dir)
   return results
+}
+
+function packArdoPackage(packDir: string): string {
+  fs.mkdirSync(packDir, { recursive: true })
+  execFileSync("pnpm", ["pack", "--pack-destination", packDir], {
+    cwd: ardoPackageDir,
+    stdio: "pipe",
+    timeout: 120_000,
+  })
+  const tarball = fs.readdirSync(packDir).find((file) => file.endsWith(".tgz"))
+  if (tarball == null) {
+    throw new Error("Ardo package tarball was not created")
+  }
+  return path.join(packDir, tarball)
 }
 
 describe("scaffold integration build", () => {
@@ -79,10 +93,10 @@ export function greet(name: string, config?: GreeterConfig): string {
 `
     )
 
-    // 4. Patch package.json — use local ardo (wildcard deps resolve via ardo)
+    // 4. Patch package.json — exercise the published-package boundary.
     const pkgPath = path.join(tmpDir, "package.json")
     const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"))
-    pkg.dependencies.ardo = `file:${ardoPackageDir}`
+    pkg.dependencies.ardo = `file:${packArdoPackage(path.join(tmpDir, "packages"))}`
     fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2))
 
     // 5. Install dependencies


### PR DESCRIPTION
Fixes #302
Fixes #304

## Summary

- make `lucide-react` a required peer and cover the scaffold against a packed `ardo` tarball
- generate OpenAPI reference files only for the client build pass and protect the SSR lifecycle with a regression test
- align v4.2 adoption, reference-project, feature-status, and installation guidance with the shipped surface

## Validation

- `pnpm build`
- `pnpm test:coverage` (227 tests)
- `pnpm test:integration` (32 tests, including packed consumer scaffold)
- `pnpm typecheck`
- `pnpm lint --quiet`
- `pnpm format:check`
- `pnpm docs:budgets`